### PR TITLE
Refactor indexer to use LiteDB

### DIFF
--- a/WannaTool/App.xaml.cs
+++ b/WannaTool/App.xaml.cs
@@ -27,9 +27,9 @@ namespace WannaTool
             base.OnStartup(e);
         }
 
-        protected override async void OnExit(ExitEventArgs e)
+        protected override void OnExit(ExitEventArgs e)
         {
-            await Indexer.SaveIndexAsync();
+            Indexer.Dispose();
             base.OnExit(e);
         }
     }

--- a/WannaTool/MainWindow.xaml.cs
+++ b/WannaTool/MainWindow.xaml.cs
@@ -268,11 +268,6 @@ namespace WannaTool
                 return;
             }
 
-            if (!Indexer.IsReady)
-            {
-                await Indexer.LoadIndexAsync();
-                Indexer.MarkAsReady();
-            }
 
             var colon = query.IndexOf(':');
             if (colon > 0 && colon < query.Length - 1)


### PR DESCRIPTION
## Summary
- refactor the indexer to use LiteDB and scan all fixed drives
- watch entire drives for changes
- dispose the indexer on application exit
- drop old in-memory initialization logic

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851e3407334832f99a1d2a2548da8ce