### PR TITLE
Experimental

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,4 @@
+﻿[*.cs]
+
+# CS8600: Conversion de littéral ayant une valeur null ou d'une éventuelle valeur null en type non-nullable.
+dotnet_diagnostic.CS8600.severity = silent

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,24 @@
-# Auto detect text files and perform LF normalization
+# Detect C# files
+*.cs linguist-language=C#
+
+# Detect XAML files
+*.xaml linguist-language=XAML
+
+# Detect JSON files
+*.json linguist-language=JSON
+
+# Detect Markdown files
+*.md linguist-language=Markdown
+
+# Detect YAML files (if needed later)
+*.yml linguist-language=YAML
+*.yaml linguist-language=YAML
+
+# Detect batch files
+*.bat linguist-language=Batchfile
+
+# Detect Shell scripts
+*.sh linguist-language=Shell
+
+# General text files
 * text=auto

--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ obj/
 
 # Visual Studio Code settings
 .vscode/
+.vs/
 
 # Rider settings
 .idea/

--- a/README.md
+++ b/README.md
@@ -42,11 +42,11 @@ For development:
    ```bash
    git clone https://github.com/laxyny/wannatool.git
 
---
+---
 
 ## License
 
-This project is licensed under the MIT License. See the [LICENSE](LICENSE) file for details.
+This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
 
 ## Credits
 

--- a/WannaTool.sln
+++ b/WannaTool.sln
@@ -5,6 +5,11 @@ VisualStudioVersion = 17.9.34701.34
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WannaTool", "WannaTool\WannaTool.csproj", "{0C08CAB9-135D-4F27-A5EE-896BC2AFC473}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{02EA681E-C7D8-13C7-8484-4AC65E1B71E8}"
+	ProjectSection(SolutionItems) = preProject
+		.editorconfig = .editorconfig
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU

--- a/WannaTool.sln
+++ b/WannaTool.sln
@@ -1,0 +1,25 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.9.34701.34
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WannaTool", "WannaTool\WannaTool.csproj", "{0C08CAB9-135D-4F27-A5EE-896BC2AFC473}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{0C08CAB9-135D-4F27-A5EE-896BC2AFC473}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0C08CAB9-135D-4F27-A5EE-896BC2AFC473}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0C08CAB9-135D-4F27-A5EE-896BC2AFC473}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0C08CAB9-135D-4F27-A5EE-896BC2AFC473}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {962D2C91-2C12-420B-97B9-36C57D7DF3E8}
+	EndGlobalSection
+EndGlobal

--- a/WannaTool/App.xaml
+++ b/WannaTool/App.xaml
@@ -1,0 +1,46 @@
+﻿<Application x:Class="WannaTool.App"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:local="clr-namespace:WannaTool"
+             xmlns:controls="clr-namespace:System.Windows.Controls;assembly=PresentationFramework"
+             StartupUri="/MainWindow.xaml">
+    <Application.Resources>
+        <!-- Définition de StringNullOrEmptyToVisibilityConverter -->
+        <local:StringNullOrEmptyToVisibilityConverter x:Key="StringNullOrEmptyToVisibilityConverter" />
+        <local:StringNotNullOrEmptyToVisibilityConverter x:Key="StringNotNullOrEmptyToVisibilityConverter" />
+
+        <Style TargetType="{x:Type ScrollViewer}">
+            <Setter Property="Template">
+                <Setter.Value>
+                    <ControlTemplate TargetType="{x:Type ScrollViewer}">
+                        <Grid>
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="*"/>
+                                <ColumnDefinition Width="Auto"/>
+                            </Grid.ColumnDefinitions>
+                            <Grid.RowDefinitions>
+                                <RowDefinition Height="*"/>
+                                <RowDefinition Height="Auto"/>
+                            </Grid.RowDefinitions>
+
+                            <ScrollContentPresenter Grid.Column="0" Grid.Row="0" Content="{TemplateBinding Content}" />
+
+                            <ScrollBar Grid.Column="1" Grid.Row="0" Orientation="Vertical"
+                               Visibility="{TemplateBinding ComputedVerticalScrollBarVisibility}"
+                               Maximum="{TemplateBinding ScrollableHeight}"
+                               ViewportSize="{TemplateBinding ViewportHeight}"
+                               Value="{TemplateBinding VerticalOffset}" />
+
+                            <ScrollBar Grid.Column="0" Grid.Row="1" Orientation="Horizontal"
+                               Visibility="{TemplateBinding ComputedHorizontalScrollBarVisibility}"
+                               Maximum="{TemplateBinding ScrollableWidth}"
+                               ViewportSize="{TemplateBinding ViewportWidth}"
+                               Value="{TemplateBinding HorizontalOffset}" />
+                        </Grid>
+                    </ControlTemplate>
+                </Setter.Value>
+            </Setter>
+        </Style>
+
+    </Application.Resources>
+</Application>

--- a/WannaTool/App.xaml
+++ b/WannaTool/App.xaml
@@ -1,46 +1,7 @@
-﻿<Application x:Class="WannaTool.App"
+<Application x:Class="WannaTool.App"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:local="clr-namespace:WannaTool"
-             xmlns:controls="clr-namespace:System.Windows.Controls;assembly=PresentationFramework"
-             StartupUri="/MainWindow.xaml">
+             StartupUri="MainWindow.xaml">
     <Application.Resources>
-        <!-- Définition de StringNullOrEmptyToVisibilityConverter -->
-        <local:StringNullOrEmptyToVisibilityConverter x:Key="StringNullOrEmptyToVisibilityConverter" />
-        <local:StringNotNullOrEmptyToVisibilityConverter x:Key="StringNotNullOrEmptyToVisibilityConverter" />
-
-        <Style TargetType="{x:Type ScrollViewer}">
-            <Setter Property="Template">
-                <Setter.Value>
-                    <ControlTemplate TargetType="{x:Type ScrollViewer}">
-                        <Grid>
-                            <Grid.ColumnDefinitions>
-                                <ColumnDefinition Width="*"/>
-                                <ColumnDefinition Width="Auto"/>
-                            </Grid.ColumnDefinitions>
-                            <Grid.RowDefinitions>
-                                <RowDefinition Height="*"/>
-                                <RowDefinition Height="Auto"/>
-                            </Grid.RowDefinitions>
-
-                            <ScrollContentPresenter Grid.Column="0" Grid.Row="0" Content="{TemplateBinding Content}" />
-
-                            <ScrollBar Grid.Column="1" Grid.Row="0" Orientation="Vertical"
-                               Visibility="{TemplateBinding ComputedVerticalScrollBarVisibility}"
-                               Maximum="{TemplateBinding ScrollableHeight}"
-                               ViewportSize="{TemplateBinding ViewportHeight}"
-                               Value="{TemplateBinding VerticalOffset}" />
-
-                            <ScrollBar Grid.Column="0" Grid.Row="1" Orientation="Horizontal"
-                               Visibility="{TemplateBinding ComputedHorizontalScrollBarVisibility}"
-                               Maximum="{TemplateBinding ScrollableWidth}"
-                               ViewportSize="{TemplateBinding ViewportWidth}"
-                               Value="{TemplateBinding HorizontalOffset}" />
-                        </Grid>
-                    </ControlTemplate>
-                </Setter.Value>
-            </Setter>
-        </Style>
-
     </Application.Resources>
 </Application>

--- a/WannaTool/App.xaml.cs
+++ b/WannaTool/App.xaml.cs
@@ -27,9 +27,9 @@ namespace WannaTool
             base.OnStartup(e);
         }
 
-        protected override async void OnExit(ExitEventArgs e)
+        protected override void OnExit(ExitEventArgs e)
         {
-            await Indexer.SaveIndexAsync();
+            Indexer.Dispose();
             base.OnExit(e);
         }
     }

--- a/WannaTool/App.xaml.cs
+++ b/WannaTool/App.xaml.cs
@@ -1,14 +1,37 @@
-﻿using System.Configuration;
+﻿using Microsoft.Toolkit.Uwp.Notifications;
+using System.Configuration;
 using System.Data;
 using System.Windows;
+using System.Diagnostics;
 
 namespace WannaTool
 {
-    /// <summary>
-    /// Interaction logic for App.xaml
-    /// </summary>
     public partial class App : System.Windows.Application
     {
+        protected override void OnStartup(StartupEventArgs e)
+        {
+            ToastNotificationManagerCompat.OnActivated += toastArgs =>
+            {
+                var args = ToastArguments.Parse(toastArgs.Argument);
+                if (args["action"] == "openScreenshot"
+                    && args.TryGetValue("path", out var path))
+                {
+                    Process.Start(new ProcessStartInfo
+                    {
+                        FileName = path,
+                        UseShellExecute = true
+                    });
+                }
+            };
+
+            base.OnStartup(e);
+        }
+
+        protected override async void OnExit(ExitEventArgs e)
+        {
+            await Indexer.SaveIndexAsync();
+            base.OnExit(e);
+        }
     }
 
 }

--- a/WannaTool/App.xaml.cs
+++ b/WannaTool/App.xaml.cs
@@ -1,0 +1,14 @@
+﻿using System.Configuration;
+using System.Data;
+using System.Windows;
+
+namespace WannaTool
+{
+    /// <summary>
+    /// Interaction logic for App.xaml
+    /// </summary>
+    public partial class App : System.Windows.Application
+    {
+    }
+
+}

--- a/WannaTool/AssemblyInfo.cs
+++ b/WannaTool/AssemblyInfo.cs
@@ -1,0 +1,10 @@
+using System.Windows;
+
+[assembly: ThemeInfo(
+    ResourceDictionaryLocation.None,            //where theme specific resource dictionaries are located
+                                                //(used if a resource is not found in the page,
+                                                // or application resource dictionaries)
+    ResourceDictionaryLocation.SourceAssembly   //where the generic resource dictionary is located
+                                                //(used if a resource is not found in the page,
+                                                // app, or any theme specific resource dictionaries)
+)]

--- a/WannaTool/Classes/IconLoader.cs
+++ b/WannaTool/Classes/IconLoader.cs
@@ -1,0 +1,97 @@
+﻿using System;
+using System.Runtime.Caching;
+using System.Windows;
+using System.Windows.Interop;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+using System.IO;
+using System.Runtime.InteropServices;
+
+static class IconLoader
+{
+    // Cache pour ne garder en mémoire qu’un nombre limité d’icônes
+    private static readonly MemoryCache _cache = new MemoryCache("IconCache");
+    private static readonly CacheItemPolicy _policy = new CacheItemPolicy
+    {
+        SlidingExpiration = TimeSpan.FromMinutes(5),
+    };
+
+    public static ImageSource? GetIcon(string path, bool isFolder)
+    {
+        // clé de cache
+        var key = (isFolder ? "D:" : "F:") + path.ToLowerInvariant();
+        if (_cache.Get(key) is ImageSource imgCached)
+            return imgCached;
+
+        // Flags et attributs
+        const uint SHGFI_ICON = 0x100;
+        const uint SHGFI_SMALLICON = 0x1;
+        const uint SHGFI_USEFILEATTRIBUTES = 0x10;
+        const uint FILE_ATTRIBUTE_NORMAL = 0x80;
+        const uint FILE_ATTRIBUTE_DIRECTORY = 0x10;
+
+        var flags = SHGFI_ICON | SHGFI_SMALLICON | SHGFI_USEFILEATTRIBUTES;
+        var attributes = isFolder
+                           ? FILE_ATTRIBUTE_DIRECTORY
+                           : FILE_ATTRIBUTE_NORMAL;
+
+        // Appel P/Invoke
+        SHFILEINFO shfi = new();
+        IntPtr result = SHGetFileInfo(
+            path,
+            attributes,
+            out shfi,
+            (uint)Marshal.SizeOf<SHFILEINFO>(),
+            flags);
+
+        // Si on n’a pas récupéré d’icône, on renvoie null (ou une icône fallback)
+        if (shfi.hIcon == IntPtr.Zero)
+            return null;
+
+        // Création du BitmapSource et nettoyage
+        var icon = Imaging.CreateBitmapSourceFromHIcon(
+            shfi.hIcon,
+            Int32Rect.Empty,
+            BitmapSizeOptions.FromEmptyOptions());
+        DestroyIcon(shfi.hIcon);
+
+        _cache.Add(key, icon, _policy);
+        return icon;
+    }
+
+    #region P/Invoke
+    [DllImport("shell32.dll", CharSet = CharSet.Unicode)]
+    private static extern IntPtr SHGetFileInfo(
+        string pszPath, uint dwFileAttributes,
+        out SHFILEINFO psfi, uint cbFileInfo, uint uFlags);
+
+    private static IntPtr SHGetFileIcon(string path, bool isFolder)
+    {
+        const uint SHGFI_ICON = 0x000000100;
+        const uint SHGFI_SMALLICON = 0x000000001;
+        const uint FILE_ATTRIBUTE_DIRECTORY = 0x10;
+
+        SHFILEINFO shfi;
+        SHGetFileInfo(path,
+            isFolder ? FILE_ATTRIBUTE_DIRECTORY : 0,
+            out shfi, (uint)Marshal.SizeOf<SHFILEINFO>(),
+            SHGFI_ICON | SHGFI_SMALLICON);
+        return shfi.hIcon;
+    }
+
+    [DllImport("user32.dll", SetLastError = true)]
+    private static extern bool DestroyIcon(IntPtr hIcon);
+
+    [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+    private struct SHFILEINFO
+    {
+        public IntPtr hIcon;
+        public int iIcon;
+        public uint dwAttributes;
+        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 260)]
+        public string szDisplayName;
+        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 80)]
+        public string szTypeName;
+    }
+    #endregion
+}

--- a/WannaTool/Classes/IconLoader.cs
+++ b/WannaTool/Classes/IconLoader.cs
@@ -9,7 +9,6 @@ using System.Runtime.InteropServices;
 
 static class IconLoader
 {
-    // Cache pour ne garder en mémoire qu’un nombre limité d’icônes
     private static readonly MemoryCache _cache = new MemoryCache("IconCache");
     private static readonly CacheItemPolicy _policy = new CacheItemPolicy
     {
@@ -18,12 +17,10 @@ static class IconLoader
 
     public static ImageSource? GetIcon(string path, bool isFolder)
     {
-        // clé de cache
         var key = (isFolder ? "D:" : "F:") + path.ToLowerInvariant();
         if (_cache.Get(key) is ImageSource imgCached)
             return imgCached;
 
-        // Flags et attributs
         const uint SHGFI_ICON = 0x100;
         const uint SHGFI_SMALLICON = 0x1;
         const uint SHGFI_USEFILEATTRIBUTES = 0x10;
@@ -35,7 +32,6 @@ static class IconLoader
                            ? FILE_ATTRIBUTE_DIRECTORY
                            : FILE_ATTRIBUTE_NORMAL;
 
-        // Appel P/Invoke
         SHFILEINFO shfi = new();
         IntPtr result = SHGetFileInfo(
             path,
@@ -44,11 +40,9 @@ static class IconLoader
             (uint)Marshal.SizeOf<SHFILEINFO>(),
             flags);
 
-        // Si on n’a pas récupéré d’icône, on renvoie null (ou une icône fallback)
         if (shfi.hIcon == IntPtr.Zero)
             return null;
 
-        // Création du BitmapSource et nettoyage
         var icon = Imaging.CreateBitmapSourceFromHIcon(
             shfi.hIcon,
             Int32Rect.Empty,

--- a/WannaTool/Classes/Indexer.cs
+++ b/WannaTool/Classes/Indexer.cs
@@ -1,67 +1,74 @@
+using System;
 using System.IO;
-using System.Text.Json;
 using System.IO.Compression;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json;
+using System.Threading.Tasks;
 using Microsoft.Toolkit.Uwp.Notifications;
+using Timer = System.Timers.Timer;
 
 namespace WannaTool
 {
     public static class Indexer
     {
+        // Struct léger pour l'index en mémoire
+        public readonly record struct IndexEntry(string DisplayName, string FullPath, bool IsFolder);
         private static readonly string IndexFilePath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "index.json.gz");
-        private static List<MainWindow.SearchResult> _index = new List<MainWindow.SearchResult>();
-        private static FileSystemWatcher _watcher;
+        private static List<IndexEntry> _index = new List<IndexEntry>();
         public static bool IsReady { get; set; } = false;
-        private static bool _saveScheduled = false;
 
-        public static async Task InitializeAsync()
+        public static void MarkAsReady() => IsReady = true;
+
+        private static readonly Timer _saveTimer = new Timer(5000)
         {
-            if (File.Exists(IndexFilePath))
-            {
-                await LoadIndexAsync();
-            }
-            else
-            {
-                await BuildIndexAsync();
-                await SaveIndexAsync();
-            }
+            AutoReset = false
+        };
 
-            StartWatching();
-            IsReady = true;
+        static Indexer()
+        {
+            // À la fin des 5 s sans nouvel appel, on sauve.
+            _saveTimer.Elapsed += async (s, e) => {
+                await SaveIndexAsync();
+            };
         }
 
+        // Extensions autorisées
         private static readonly HashSet<string> AllowedExtensions = new(StringComparer.OrdinalIgnoreCase)
-{
-    ".exe", ".pdf", ".docx", ".xlsx", ".pptx", ".txt",
-    ".jpg", ".jpeg", ".png", ".gif", ".bmp", ".mp4", ".avi", ".mkv", ".mov",
-    ".zip", ".rar", ".7z", ".tar", ".gz",
-    ".html", ".css", ".js", ".json", ".xml", ".csv",
-    ".psd", ".ai", ".blend", ".fbx", ".obj",
-    ".apk", ".iso", ".bat", ".cmd"
-};
+        {
+            ".exe", ".pdf", ".docx", ".xlsx", ".pptx", ".txt",
+            ".jpg", ".jpeg", ".png", ".gif", ".bmp", ".mp4", ".avi", ".mkv", ".mov",
+            ".zip", ".rar", ".7z", ".tar", ".gz",
+            ".html", ".css", ".js", ".json", ".xml", ".csv",
+            ".psd", ".ai", ".blend", ".fbx", ".obj",
+            ".apk", ".iso", ".bat", ".cmd"
+        };
 
+        // Extensions ignorées
         private static readonly HashSet<string> IgnoredExtensions = new(StringComparer.OrdinalIgnoreCase)
-{
-    ".dll", ".sys", ".tmp", ".log", ".bak", ".old",
-    ".cache", ".msi", ".dat", ".bin", ".db", ".db-shm", ".db-wal",
-    ".jsonl", ".lock", ".idx", ".thumb", ".mdmp", ".dmp"
-};
+        {
+            ".dll", ".sys", ".tmp", ".log", ".bak", ".old",
+            ".cache", ".msi", ".dat", ".bin", ".db", ".db-shm", ".db-wal",
+            ".jsonl", ".lock", ".idx", ".thumb", ".mdmp", ".dmp"
+        };
 
+        // Dossiers à ignorer
         private static readonly List<string> IgnoredFolders = new()
-{
-    "C:\\Windows",
-    "C:\\Program Files",
-    "C:\\Program Files (x86)",
-    "C:\\ProgramData",
-    "C:\\$Recycle.Bin",
-    "C:\\System Volume Information",
-    "C:\\Users\\Default",
-    "AppData",
-    "node_modules",
-    ".git",
-    "\\bin",
-    "\\obj",
-    "\\.vs"
-};
+        {
+            "C:\\Windows",
+            "C:\\Program Files",
+            "C:\\Program Files (x86)",
+            "C:\\ProgramData",
+            "C:\\$Recycle.Bin",
+            "C:\\System Volume Information",
+            "C:\\Users\\Default",
+            "AppData",
+            "node_modules",
+            ".git",
+            "\\bin",
+            "\\obj",
+            "\\.vs"
+        };
 
         private static bool ShouldIndexFile(string filePath)
         {
@@ -69,27 +76,19 @@ namespace WannaTool
             {
                 var extension = Path.GetExtension(filePath);
                 if (string.IsNullOrEmpty(extension)) return false;
-
                 if (IgnoredExtensions.Contains(extension)) return false;
                 if (!AllowedExtensions.Contains(extension)) return false;
-
                 foreach (var ignored in IgnoredFolders)
                 {
                     if (filePath.Contains(ignored, StringComparison.OrdinalIgnoreCase))
                         return false;
                 }
-
                 return true;
             }
             catch
             {
                 return false;
             }
-        }
-
-        public static void MarkAsReady()
-        {
-            IsReady = true;
         }
 
         private static bool ShouldIndexFolder(string folderPath)
@@ -102,33 +101,113 @@ namespace WannaTool
             return true;
         }
 
+        // Initialisation de l'index
+        public static async Task InitializeAsync()
+        {
+            if (File.Exists(IndexFilePath))
+            { 
+                await LoadIndexAsync();
+                _ = SyncIndexAsync();
+            }
+            else
+            {
+                await BuildIndexAsync();
+                await SaveIndexAsync();
+            }
+
+            StartWatching();
+            IsReady = true;
+        }
+
+        // Chargement de l'index depuis le fichier compressé
         public static async Task LoadIndexAsync()
         {
             try
             {
                 using var fileStream = new FileStream(IndexFilePath, FileMode.Open, FileAccess.Read, FileShare.Read);
                 using var gzip = new GZipStream(fileStream, CompressionMode.Decompress);
-                _index = await JsonSerializer.DeserializeAsync<List<MainWindow.SearchResult>>(gzip) ?? new();
+                _index = await JsonSerializer.DeserializeAsync<List<IndexEntry>>(gzip) ?? new();
             }
             catch (FileNotFoundException)
             {
-                Console.WriteLine("Aucun index existant trouvé. Reconstruction nécessaire.");
-                _index = new List<MainWindow.SearchResult>();
+                Console.WriteLine("Aucun index existant trouvé. Reconstruction...");
+                await BuildIndexAsync();
             }
             catch (Exception ex)
             {
                 Console.WriteLine($"Erreur lors du chargement de l'index: {ex.Message}");
-                _index = new List<MainWindow.SearchResult>();
             }
         }
 
+        public static async Task SyncIndexAsync()
+        {
+            // Construire l'ensemble (HashSet) des chemins actuels
+            var roots = new[]
+            {
+                Environment.GetFolderPath(Environment.SpecialFolder.Desktop),
+                Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments),
+                GetDownloadsFolderPath()
+            };
+            var actualPaths = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+            foreach (var root in roots)
+            {
+                if (!Directory.Exists(root))
+                    continue;
+
+                // Dossiers
+                try
+                {
+                    foreach (var dir in Directory.EnumerateDirectories(root, "*", SearchOption.AllDirectories))
+                    {
+                        if (ShouldIndexFolder(dir))
+                            actualPaths.Add(dir);
+                    }
+                }
+                catch (UnauthorizedAccessException) { /* skip this branch */ }
+                catch (PathTooLongException) { /* skip */ }
+
+                // Fichiers
+                try
+                {
+                    foreach (var file in Directory.EnumerateFiles(root, "*", SearchOption.AllDirectories))
+                    {
+                        if (ShouldIndexFile(file))
+                            actualPaths.Add(file);
+                    }
+                }
+                catch (UnauthorizedAccessException) { /* skip this branch */ }
+                catch (PathTooLongException) { /* skip */ }
+            }
+
+            // Supprimer les entrées obsolètes
+            _index.RemoveAll(e => !actualPaths.Contains(e.FullPath));
+
+            // Ajouter les nouveaux chemins
+            var knownPaths = new HashSet<string>(_index.Select(e => e.FullPath), StringComparer.OrdinalIgnoreCase);
+            foreach (var path in actualPaths)
+            {
+                if (knownPaths.Add(path))
+                {
+                    var name = Path.GetFileName(path);
+                    var isFolder = Directory.Exists(path);
+                    _index.Add(new IndexEntry(name, path, isFolder));
+                }
+            }
+
+            // Sauvegarde immédiate
+            await SaveIndexAsync();
+        }
+
+        // Efface l'index en mémoire
         public static void ClearIndex()
         {
             _index.Clear();
             IsReady = false;
         }
 
-        private static async Task SaveIndexAsync()
+        // Sauvegarde de l'index dans un .gz
+        public static async Task SaveIndexAsync()
         {
             try
             {
@@ -136,111 +215,73 @@ namespace WannaTool
                 using var gzip = new GZipStream(fileStream, CompressionMode.Compress);
                 await JsonSerializer.SerializeAsync(gzip, _index);
             }
-            catch (IOException ex)
-            {
-                Console.WriteLine($"Erreur SaveIndexAsync: {ex.Message}");
-                // Ici tu peux logger ou faire un retry léger si tu veux
-            }
             catch (Exception ex)
             {
-                Console.WriteLine($"Erreur générale SaveIndexAsync: {ex.Message}");
+                Console.WriteLine($"Erreur lors de la sauvegarde de l'index: {ex.Message}");
             }
         }
 
+        // Construction initiale de l'index
         private static async Task BuildIndexAsync()
         {
             var rootFolders = new[]
             {
-        "C:\\"
-    };
-
-            var results = new List<MainWindow.SearchResult>();
-
+                Environment.GetFolderPath(Environment.SpecialFolder.Desktop),
+                Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments),
+                GetDownloadsFolderPath()
+            };
+            var entries = new List<IndexEntry>();
             Utils.ShowToast("Indexing started", "WannaTool is scanning your files...");
+
             foreach (var root in rootFolders)
             {
-                if (!Directory.Exists(root)) continue;
-                await ScanDirectoryRecursiveAsync(root, results);
+                if (Directory.Exists(root))
+                    await ScanDirectoryRecursiveAsync(root, entries);
             }
 
-            _index = results;
-            Utils.ShowToast("Indexing completed", $"All files have been indexed successfully. {results.Count} files");
-            Console.WriteLine($"Indexation terminée avec {results.Count} fichiers indexés.");
+            _index = entries;
+            Utils.ShowToast("Indexing completed", $"{_index.Count} entrées indexées");
+            Console.WriteLine($"Indexation terminée avec {_index.Count} entrées.");
         }
 
-        private static async Task ScanDirectoryRecursiveAsync(string currentFolder, List<MainWindow.SearchResult> results)
+        // Parcours récursif et ajout d'entrées légères
+        private static async Task ScanDirectoryRecursiveAsync(string currentFolder, List<IndexEntry> entries)
         {
             try
             {
-                var directoryInfo = new DirectoryInfo(currentFolder);
-
-                if (!ShouldIndexFolder(directoryInfo.FullName))
+                if (!ShouldIndexFolder(currentFolder))
                     return;
 
-                // Ajouter ce dossier dans l'index
-                results.Add(new MainWindow.SearchResult
-                {
-                    DisplayName = directoryInfo.Name,
-                    FullPath = directoryInfo.FullName,
-                    Icon = null,
-                    IsFolder = true
-                });
+                var dirInfo = new DirectoryInfo(currentFolder);
+                entries.Add(new IndexEntry(dirInfo.Name, dirInfo.FullName, true));
 
-                // Parcourir les fichiers
-                foreach (var file in directoryInfo.GetFiles())
+                foreach (var file in dirInfo.GetFiles())
                 {
-                    try
-                    {
-                        if (ShouldIndexFile(file.FullName))
-                        {
-                            results.Add(new MainWindow.SearchResult
-                            {
-                                DisplayName = file.Name,
-                                FullPath = file.FullName,
-                                Icon = null,
-                                IsFolder = false
-                            });
-                        }
-                    }
-                    catch
-                    {
-                        // Skip file access errors
-                    }
+                    if (ShouldIndexFile(file.FullName))
+                        entries.Add(new IndexEntry(file.Name, file.FullName, false));
                 }
 
-                // Parcourir les sous-dossiers
-                foreach (var dir in directoryInfo.GetDirectories())
-                {
-                    try
-                    {
-                        await ScanDirectoryRecursiveAsync(dir.FullName, results);
-                    }
-                    catch
-                    {
-                        // Skip folder access errors
-                    }
-                }
+                foreach (var dir in dirInfo.GetDirectories())
+                    await ScanDirectoryRecursiveAsync(dir.FullName, entries);
             }
-            catch (UnauthorizedAccessException)
-            {
-                // Skip unauthorized folders
-            }
+            catch (UnauthorizedAccessException) { }
             catch (Exception ex)
             {
-                Console.WriteLine($"Erreur inattendue : {ex.Message}");
+                Console.WriteLine($"Erreur lors du scan du dossier {currentFolder}: {ex.Message}");
             }
         }
 
         private static List<FileSystemWatcher> _watchers = new();
 
+        // Surveillance des dossiers clés
         private static void StartWatching()
         {
             var foldersToWatch = new[]
             {
-        Environment.GetFolderPath(Environment.SpecialFolder.Desktop),
-        Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments),
-        GetDownloadsFolderPath()
-    };
+                Environment.GetFolderPath(Environment.SpecialFolder.Desktop),
+                Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments),
+                GetDownloadsFolderPath()
+            };
 
             foreach (var folder in foldersToWatch)
             {
@@ -260,89 +301,83 @@ namespace WannaTool
             }
         }
 
-
-        private static string GetDownloadsFolderPath()
-        {
-            // Remplacement de l'utilisation de Environment.SpecialFolder.Downloads  
-            return Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), "Downloads");
-        }
-
         private static void AddFile(string path)
         {
             try
             {
                 if (Directory.Exists(path))
                 {
-                    _index.Add(new MainWindow.SearchResult
-                    {
-                        DisplayName = Path.GetFileName(path),
-                        FullPath = path,
-                        Icon = null,
-                        IsFolder = true
-                    });
-                    ScheduleSave();
+                    _index.Add(new IndexEntry(Path.GetFileName(path), path, true));
                 }
                 else if (File.Exists(path) && ShouldIndexFile(path))
                 {
-                    _index.Add(new MainWindow.SearchResult
-                    {
-                        DisplayName = Path.GetFileName(path),
-                        FullPath = path,
-                        Icon = null,
-                        IsFolder = false
-                    });
-                    ScheduleSave();
+                    _index.Add(new IndexEntry(Path.GetFileName(path), path, false));
                 }
+                ScheduleSave();
             }
             catch (Exception ex)
             {
-                Console.WriteLine($"Erreur lors de l'ajout de fichier {path}: {ex.Message}");
+                Console.WriteLine($"Erreur ajout fichier {path}: {ex.Message}");
             }
         }
 
         private static void RemoveFile(string path)
         {
-            _index.RemoveAll(x => x.FullPath.Equals(path, StringComparison.OrdinalIgnoreCase));
+            _index.RemoveAll(e => e.FullPath.Equals(path, StringComparison.OrdinalIgnoreCase));
             ScheduleSave();
         }
 
         private static void UpdateFile(string oldPath, string newPath)
         {
-            var existing = _index.FirstOrDefault(x => x.FullPath.Equals(oldPath, StringComparison.OrdinalIgnoreCase));
-            if (existing != null)
-            {
-                existing.DisplayName = Path.GetFileName(newPath);
-                existing.FullPath = newPath;
-                existing.IsFolder = Directory.Exists(newPath);
-                existing.Icon = null; // Placeholder for icon
-            }
-            else
-            {
-                AddFile(newPath);
-            }
-
+            RemoveFile(oldPath);
+            AddFile(newPath);
             ScheduleSave();
         }
 
-
+        // Recherche : on recrée les objets WPF uniquement pour l'affichage
         public static List<MainWindow.SearchResult> Search(string query)
         {
             return _index
-                .Where(f => f.DisplayName.Contains(query, StringComparison.OrdinalIgnoreCase))
+                .Where(e => e.DisplayName.Contains(query, StringComparison.OrdinalIgnoreCase))
                 .Take(20)
+                .Select(e => new MainWindow.SearchResult
+                {
+                    DisplayName = e.DisplayName,
+                    FullPath = e.FullPath,
+                    IsFolder = e.IsFolder,
+                })
+                .ToList();
+        }
+
+        public static List<MainWindow.SearchResult> Search(string query, IEnumerable<string> extensions)
+        {
+            var extSet = new HashSet<string>(extensions, StringComparer.OrdinalIgnoreCase);
+            return _index
+                .Where(e =>
+                {
+                    if (e.IsFolder) return false;
+                    var ext = Path.GetExtension(e.FullPath);
+                    return extSet.Contains(ext)
+                        && e.DisplayName.Contains(query, StringComparison.OrdinalIgnoreCase);
+                })
+                .Take(20)
+                .Select(e => new MainWindow.SearchResult
+                {
+                    DisplayName = e.DisplayName,
+                    FullPath = e.FullPath,
+                    IsFolder = false
+                })
                 .ToList();
         }
 
         private static void ScheduleSave()
         {
-            if (_saveScheduled) return;
-            _saveScheduled = true;
-
-            Task.Delay(30000).ContinueWith(async _ =>
-            {
-                await SaveIndexAsync();
-                _saveScheduled = false;
-            });
+            // À chaque événement, on redémarre le timer
+            _saveTimer.Stop();
+            _saveTimer.Start();
         }
+
+        private static string GetDownloadsFolderPath()
+            => Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), "Downloads");
     }
 }

--- a/WannaTool/Classes/Indexer.cs
+++ b/WannaTool/Classes/Indexer.cs
@@ -1,6 +1,7 @@
 using System.IO;
 using System.Text.Json;
 using System.IO.Compression;
+using Microsoft.Toolkit.Uwp.Notifications;
 
 namespace WannaTool
 {
@@ -155,6 +156,7 @@ namespace WannaTool
 
             var results = new List<MainWindow.SearchResult>();
 
+            Utils.ShowToast("Indexing started", "WannaTool is scanning your files...");
             foreach (var root in rootFolders)
             {
                 if (!Directory.Exists(root)) continue;
@@ -162,6 +164,7 @@ namespace WannaTool
             }
 
             _index = results;
+            Utils.ShowToast("Indexing completed", $"All files have been indexed successfully. {results.Count} files");
             Console.WriteLine($"Indexation terminée avec {results.Count} fichiers indexés.");
         }
 

--- a/WannaTool/Classes/Indexer.cs
+++ b/WannaTool/Classes/Indexer.cs
@@ -1,0 +1,345 @@
+using System.IO;
+using System.Text.Json;
+using System.IO.Compression;
+
+namespace WannaTool
+{
+    public static class Indexer
+    {
+        private static readonly string IndexFilePath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "index.json.gz");
+        private static List<MainWindow.SearchResult> _index = new List<MainWindow.SearchResult>();
+        private static FileSystemWatcher _watcher;
+        public static bool IsReady { get; set; } = false;
+        private static bool _saveScheduled = false;
+
+        public static async Task InitializeAsync()
+        {
+            if (File.Exists(IndexFilePath))
+            {
+                await LoadIndexAsync();
+            }
+            else
+            {
+                await BuildIndexAsync();
+                await SaveIndexAsync();
+            }
+
+            StartWatching();
+            IsReady = true;
+        }
+
+        private static readonly HashSet<string> AllowedExtensions = new(StringComparer.OrdinalIgnoreCase)
+{
+    ".exe", ".pdf", ".docx", ".xlsx", ".pptx", ".txt",
+    ".jpg", ".jpeg", ".png", ".gif", ".bmp", ".mp4", ".avi", ".mkv", ".mov",
+    ".zip", ".rar", ".7z", ".tar", ".gz",
+    ".html", ".css", ".js", ".json", ".xml", ".csv",
+    ".psd", ".ai", ".blend", ".fbx", ".obj",
+    ".apk", ".iso", ".bat", ".cmd"
+};
+
+        private static readonly HashSet<string> IgnoredExtensions = new(StringComparer.OrdinalIgnoreCase)
+{
+    ".dll", ".sys", ".tmp", ".log", ".bak", ".old",
+    ".cache", ".msi", ".dat", ".bin", ".db", ".db-shm", ".db-wal",
+    ".jsonl", ".lock", ".idx", ".thumb", ".mdmp", ".dmp"
+};
+
+        private static readonly List<string> IgnoredFolders = new()
+{
+    "C:\\Windows",
+    "C:\\Program Files",
+    "C:\\Program Files (x86)",
+    "C:\\ProgramData",
+    "C:\\$Recycle.Bin",
+    "C:\\System Volume Information",
+    "C:\\Users\\Default",
+    "AppData",
+    "node_modules",
+    ".git",
+    "\\bin",
+    "\\obj",
+    "\\.vs"
+};
+
+        private static bool ShouldIndexFile(string filePath)
+        {
+            try
+            {
+                var extension = Path.GetExtension(filePath);
+                if (string.IsNullOrEmpty(extension)) return false;
+
+                if (IgnoredExtensions.Contains(extension)) return false;
+                if (!AllowedExtensions.Contains(extension)) return false;
+
+                foreach (var ignored in IgnoredFolders)
+                {
+                    if (filePath.Contains(ignored, StringComparison.OrdinalIgnoreCase))
+                        return false;
+                }
+
+                return true;
+            }
+            catch
+            {
+                return false;
+            }
+        }
+
+        public static void MarkAsReady()
+        {
+            IsReady = true;
+        }
+
+        private static bool ShouldIndexFolder(string folderPath)
+        {
+            foreach (var ignored in IgnoredFolders)
+            {
+                if (folderPath.Contains(ignored, StringComparison.OrdinalIgnoreCase))
+                    return false;
+            }
+            return true;
+        }
+
+        public static async Task LoadIndexAsync()
+        {
+            try
+            {
+                using var fileStream = new FileStream(IndexFilePath, FileMode.Open, FileAccess.Read, FileShare.Read);
+                using var gzip = new GZipStream(fileStream, CompressionMode.Decompress);
+                _index = await JsonSerializer.DeserializeAsync<List<MainWindow.SearchResult>>(gzip) ?? new();
+            }
+            catch (FileNotFoundException)
+            {
+                Console.WriteLine("Aucun index existant trouvé. Reconstruction nécessaire.");
+                _index = new List<MainWindow.SearchResult>();
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"Erreur lors du chargement de l'index: {ex.Message}");
+                _index = new List<MainWindow.SearchResult>();
+            }
+        }
+
+        public static void ClearIndex()
+        {
+            _index.Clear();
+            IsReady = false;
+        }
+
+        private static async Task SaveIndexAsync()
+        {
+            try
+            {
+                using var fileStream = new FileStream(IndexFilePath, FileMode.Create, FileAccess.Write, FileShare.None);
+                using var gzip = new GZipStream(fileStream, CompressionMode.Compress);
+                await JsonSerializer.SerializeAsync(gzip, _index);
+            }
+            catch (IOException ex)
+            {
+                Console.WriteLine($"Erreur SaveIndexAsync: {ex.Message}");
+                // Ici tu peux logger ou faire un retry léger si tu veux
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"Erreur générale SaveIndexAsync: {ex.Message}");
+            }
+        }
+
+        private static async Task BuildIndexAsync()
+        {
+            var rootFolders = new[]
+            {
+        "C:\\"
+    };
+
+            var results = new List<MainWindow.SearchResult>();
+
+            foreach (var root in rootFolders)
+            {
+                if (!Directory.Exists(root)) continue;
+                await ScanDirectoryRecursiveAsync(root, results);
+            }
+
+            _index = results;
+            Console.WriteLine($"Indexation terminée avec {results.Count} fichiers indexés.");
+        }
+
+        private static async Task ScanDirectoryRecursiveAsync(string currentFolder, List<MainWindow.SearchResult> results)
+        {
+            try
+            {
+                var directoryInfo = new DirectoryInfo(currentFolder);
+
+                if (!ShouldIndexFolder(directoryInfo.FullName))
+                    return;
+
+                // Ajouter ce dossier dans l'index
+                results.Add(new MainWindow.SearchResult
+                {
+                    DisplayName = directoryInfo.Name,
+                    FullPath = directoryInfo.FullName,
+                    Icon = null,
+                    IsFolder = true
+                });
+
+                // Parcourir les fichiers
+                foreach (var file in directoryInfo.GetFiles())
+                {
+                    try
+                    {
+                        if (ShouldIndexFile(file.FullName))
+                        {
+                            results.Add(new MainWindow.SearchResult
+                            {
+                                DisplayName = file.Name,
+                                FullPath = file.FullName,
+                                Icon = null,
+                                IsFolder = false
+                            });
+                        }
+                    }
+                    catch
+                    {
+                        // Skip file access errors
+                    }
+                }
+
+                // Parcourir les sous-dossiers
+                foreach (var dir in directoryInfo.GetDirectories())
+                {
+                    try
+                    {
+                        await ScanDirectoryRecursiveAsync(dir.FullName, results);
+                    }
+                    catch
+                    {
+                        // Skip folder access errors
+                    }
+                }
+            }
+            catch (UnauthorizedAccessException)
+            {
+                // Skip unauthorized folders
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"Erreur inattendue : {ex.Message}");
+            }
+        }
+
+        private static List<FileSystemWatcher> _watchers = new();
+
+        private static void StartWatching()
+        {
+            var foldersToWatch = new[]
+            {
+        Environment.GetFolderPath(Environment.SpecialFolder.Desktop),
+        Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments),
+        GetDownloadsFolderPath()
+    };
+
+            foreach (var folder in foldersToWatch)
+            {
+                if (!Directory.Exists(folder)) continue;
+
+                var watcher = new FileSystemWatcher(folder)
+                {
+                    IncludeSubdirectories = true,
+                    EnableRaisingEvents = true
+                };
+
+                watcher.Created += (s, e) => AddFile(e.FullPath);
+                watcher.Deleted += (s, e) => RemoveFile(e.FullPath);
+                watcher.Renamed += (s, e) => UpdateFile(e.OldFullPath, e.FullPath);
+
+                _watchers.Add(watcher);
+            }
+        }
+
+
+        private static string GetDownloadsFolderPath()
+        {
+            // Remplacement de l'utilisation de Environment.SpecialFolder.Downloads  
+            return Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), "Downloads");
+        }
+
+        private static void AddFile(string path)
+        {
+            try
+            {
+                if (Directory.Exists(path))
+                {
+                    _index.Add(new MainWindow.SearchResult
+                    {
+                        DisplayName = Path.GetFileName(path),
+                        FullPath = path,
+                        Icon = null,
+                        IsFolder = true
+                    });
+                    ScheduleSave();
+                }
+                else if (File.Exists(path) && ShouldIndexFile(path))
+                {
+                    _index.Add(new MainWindow.SearchResult
+                    {
+                        DisplayName = Path.GetFileName(path),
+                        FullPath = path,
+                        Icon = null,
+                        IsFolder = false
+                    });
+                    ScheduleSave();
+                }
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"Erreur lors de l'ajout de fichier {path}: {ex.Message}");
+            }
+        }
+
+        private static void RemoveFile(string path)
+        {
+            _index.RemoveAll(x => x.FullPath.Equals(path, StringComparison.OrdinalIgnoreCase));
+            ScheduleSave();
+        }
+
+        private static void UpdateFile(string oldPath, string newPath)
+        {
+            var existing = _index.FirstOrDefault(x => x.FullPath.Equals(oldPath, StringComparison.OrdinalIgnoreCase));
+            if (existing != null)
+            {
+                existing.DisplayName = Path.GetFileName(newPath);
+                existing.FullPath = newPath;
+                existing.IsFolder = Directory.Exists(newPath);
+                existing.Icon = null; // Placeholder for icon
+            }
+            else
+            {
+                AddFile(newPath);
+            }
+
+            ScheduleSave();
+        }
+
+
+        public static List<MainWindow.SearchResult> Search(string query)
+        {
+            return _index
+                .Where(f => f.DisplayName.Contains(query, StringComparison.OrdinalIgnoreCase))
+                .Take(20)
+                .ToList();
+        }
+
+        private static void ScheduleSave()
+        {
+            if (_saveScheduled) return;
+            _saveScheduled = true;
+
+            Task.Delay(30000).ContinueWith(async _ =>
+            {
+                await SaveIndexAsync();
+                _saveScheduled = false;
+            });
+        }
+    }
+}

--- a/WannaTool/Classes/MainViewModel.cs
+++ b/WannaTool/Classes/MainViewModel.cs
@@ -1,0 +1,241 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Input;
+using MessageBox = System.Windows.MessageBox;
+using Application = System.Windows.Application;
+using Clipboard = System.Windows.Clipboard;
+
+namespace WannaTool
+{
+    public class MainViewModel : INotifyPropertyChanged
+    {
+        private string _searchText = "";
+        private SearchResult? _selectedResult;
+        private bool _isLoading;
+        private CancellationTokenSource? _searchCts;
+
+        public ObservableCollection<SearchResult> Results { get; } = new();
+
+        public string SearchText
+        {
+            get => _searchText;
+            set
+            {
+                if (_searchText != value)
+                {
+                    _searchText = value;
+                    OnPropertyChanged(nameof(SearchText));
+                    DebounceSearch();
+                }
+            }
+        }
+
+        public SearchResult? SelectedResult
+        {
+            get => _selectedResult;
+            set
+            {
+                _selectedResult = value;
+                OnPropertyChanged(nameof(SelectedResult));
+            }
+        }
+
+        public bool IsLoading
+        {
+            get => _isLoading;
+            set
+            {
+                _isLoading = value;
+                OnPropertyChanged(nameof(IsLoading));
+            }
+        }
+
+        public ICommand ExecuteCommand { get; }
+        public ICommand NextResultCommand { get; }
+        public ICommand PreviousResultCommand { get; }
+        public ICommand CopyPathCommand { get; }
+        public ICommand OpenLocationCommand { get; }
+
+        public MainViewModel()
+        {
+            ExecuteCommand = new RelayCommand(Execute);
+            NextResultCommand = new RelayCommand(_ => MoveSelection(1));
+            PreviousResultCommand = new RelayCommand(_ => MoveSelection(-1));
+            CopyPathCommand = new RelayCommand(CopyPath);
+            OpenLocationCommand = new RelayCommand(OpenLocation);
+            
+            _ = Indexer.InitializeAsync();
+        }
+
+        private async void DebounceSearch()
+        {
+            _searchCts?.Cancel();
+            _searchCts = new CancellationTokenSource();
+            var token = _searchCts.Token;
+
+            try
+            {
+                await Task.Delay(150, token);
+                if (token.IsCancellationRequested) return;
+
+                PerformSearch();
+            }
+            catch (TaskCanceledException) { }
+        }
+
+        private void PerformSearch()
+        {
+            var query = SearchText.Trim();
+
+            if (string.IsNullOrWhiteSpace(query))
+            {
+                Results.Clear();
+                return;
+            }
+
+            var redirect = SearchRedirects.TryParseRedirect(query);
+            if (redirect != null)
+            {
+                UpdateResults(new List<SearchResult> { redirect });
+                return;
+            }
+
+            var colon = query.IndexOf(':');
+            List<SearchResult> results;
+
+            if (colon > 0 && colon < query.Length - 1)
+            {
+                var prefix = query[..colon].ToLowerInvariant();
+                var term = query[(colon + 1)..].Trim();
+                
+                string[]? exts = prefix switch
+                {
+                    "pdf" => new[] { ".pdf" },
+                    "img" => new[] { ".png", ".jpg", ".jpeg", ".gif", ".bmp" },
+                    "code" => new[] { ".cs", ".js", ".ts", ".html", ".css", ".json", ".xml", ".cpp", ".java" },
+                    "doc" => new[] { ".docx", ".doc", ".txt", ".rtf" },
+                    "exe" => new[] { ".exe", ".lnk" },
+                    _ => null
+                };
+
+                if (exts != null && !string.IsNullOrEmpty(term))
+                {
+                    results = Indexer.Search(term, exts);
+                }
+                else
+                {
+                    results = Indexer.Search(query);
+                }
+            }
+            else
+            {
+                results = Indexer.Search(query);
+            }
+
+            if (!results.Any())
+            {
+                results.Add(new SearchResult
+                {
+                    DisplayName = $"Search Google for \"{query}\"",
+                    FullPath = $"https://www.google.com/search?q={Uri.EscapeDataString(query)}",
+                    IsFolder = false
+                });
+            }
+
+            UpdateResults(results);
+        }
+
+        private void UpdateResults(List<SearchResult> newResults)
+        {
+            Application.Current.Dispatcher.Invoke(() =>
+            {
+                Results.Clear();
+                foreach (var item in newResults)
+                {
+                    Results.Add(item);
+                }
+
+                if (Results.Any())
+                {
+                    SelectedResult = Results.First();
+                }
+            });
+        }
+
+        private void MoveSelection(int direction)
+        {
+            if (!Results.Any()) return;
+
+            int index = SelectedResult != null ? Results.IndexOf(SelectedResult) : -1;
+            index += direction;
+
+            if (index < 0) index = Results.Count - 1;
+            if (index >= Results.Count) index = 0;
+
+            SelectedResult = Results[index];
+        }
+
+        private void Execute(object? parameter)
+        {
+            var result = parameter as SearchResult ?? SelectedResult;
+            if (result == null) return;
+
+            try
+            {
+                if (result.FullPath == "!help")
+                {
+                     string helpPath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "Docs", "index.html");
+                     if (File.Exists(helpPath))
+                     {
+                         Process.Start(new ProcessStartInfo(helpPath) { UseShellExecute = true });
+                     }
+                }
+                else
+                {
+                    Process.Start(new ProcessStartInfo(result.FullPath) { UseShellExecute = true });
+                }
+                
+                Application.Current.MainWindow.Hide();
+                SearchText = "";
+            }
+            catch (Exception ex)
+            {
+                MessageBox.Show($"Error opening: {ex.Message}");
+            }
+        }
+
+        private void CopyPath(object? parameter)
+        {
+            if (parameter is SearchResult res)
+            {
+                try { Clipboard.SetText(res.FullPath); } catch { }
+                Application.Current.MainWindow.Hide();
+            }
+        }
+
+        private void OpenLocation(object? parameter)
+        {
+            if (parameter is SearchResult res)
+            {
+                try 
+                { 
+                    Process.Start(new ProcessStartInfo("explorer.exe", $"/select,\"{res.FullPath}\"")); 
+                } 
+                catch { }
+                Application.Current.MainWindow.Hide();
+            }
+        }
+
+        public event PropertyChangedEventHandler? PropertyChanged;
+        protected void OnPropertyChanged(string name) =>
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
+    }
+}

--- a/WannaTool/Classes/RelayCommand.cs
+++ b/WannaTool/Classes/RelayCommand.cs
@@ -1,0 +1,33 @@
+using System;
+using System.Windows.Input;
+
+namespace WannaTool
+{
+    public class RelayCommand : ICommand
+    {
+        private readonly Action<object?> _execute;
+        private readonly Predicate<object?>? _canExecute;
+
+        public RelayCommand(Action<object?> execute, Predicate<object?>? canExecute = null)
+        {
+            _execute = execute ?? throw new ArgumentNullException(nameof(execute));
+            _canExecute = canExecute;
+        }
+
+        public bool CanExecute(object? parameter)
+        {
+            return _canExecute == null || _canExecute(parameter);
+        }
+
+        public void Execute(object? parameter)
+        {
+            _execute(parameter);
+        }
+
+        public event EventHandler? CanExecuteChanged
+        {
+            add { CommandManager.RequerySuggested += value; }
+            remove { CommandManager.RequerySuggested -= value; }
+        }
+    }
+}

--- a/WannaTool/Classes/ScreenCaptureManager.cs
+++ b/WannaTool/Classes/ScreenCaptureManager.cs
@@ -1,0 +1,129 @@
+﻿using System.Drawing.Imaging;
+using System.IO;
+using System.Runtime.InteropServices;
+using System.Windows;
+using Microsoft.Toolkit.Uwp.Notifications;
+using DataFormats = System.Windows.DataFormats;
+
+namespace WannaTool
+{
+    public static class ScreenCaptureManager
+    {
+        static class NativeClipboard
+        {
+            public const uint CF_BITMAP = 2;
+
+            [DllImport("user32.dll", SetLastError = true)]
+            public static extern bool OpenClipboard(IntPtr hWndNewOwner);
+
+            [DllImport("user32.dll", SetLastError = true)]
+            public static extern bool EmptyClipboard();
+
+            [DllImport("user32.dll", SetLastError = true)]
+            public static extern IntPtr SetClipboardData(uint uFormat, IntPtr hMem);
+
+            [DllImport("user32.dll", SetLastError = true)]
+            public static extern bool CloseClipboard();
+
+            public static void Open() => OpenClipboard(IntPtr.Zero);
+            public static void Empty() => EmptyClipboard();
+            public static void Close() => CloseClipboard();
+
+            public static void SetData(uint format, IntPtr hMem) =>
+                SetClipboardData(format, hMem);
+        }
+
+        [DllImport("gdi32.dll")]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        private static extern bool DeleteObject(IntPtr hObject);
+
+        public static void CapturePrimary()
+        {
+            Capture(false);
+        }
+
+        public static void CaptureAll()
+        {
+            Capture(true);
+        }
+
+        private static void Capture(bool allScreens)
+        {
+            try
+            {
+                var screens = allScreens ? Screen.AllScreens.OrderBy(s => s.Bounds.X).ToArray() : new[] { Screen.PrimaryScreen };
+                int totalWidth = screens.Sum(s => s.Bounds.Width);
+                int maxHeight = screens.Max(s => s.Bounds.Height);
+
+                using var bmp = new Bitmap(totalWidth, maxHeight);
+                using var g = Graphics.FromImage(bmp);
+
+                int offsetX = 0;
+                foreach (var screen in screens)
+                {
+                    g.CopyFromScreen(screen.Bounds.X, screen.Bounds.Y, offsetX, 0, screen.Bounds.Size);
+                    offsetX += screen.Bounds.Width;
+                }
+
+                // Copier dans le presse-papier (WPF Clipboard, évite la fuite mémoire)
+                System.Windows.Clipboard.SetImage(bmp.ToBitmapSource());
+
+                // Enregistrer l'image
+                var filePath = SaveScreenshot(bmp);
+
+                // Notification
+                new ToastContentBuilder()
+                    .AddText("Capture enregistrée")
+                    .AddText(allScreens ? "Tous les écrans ont été capturés." : "Écran principal capturé.")
+                    .AddArgument("action", "openScreenshot")
+                    .AddArgument("path", filePath)
+                    .AddButton(new ToastButton()
+                        .SetContent("Ouvrir")
+                        .AddArgument("action", "openScreenshot")
+                        .AddArgument("path", filePath)
+                        .SetBackgroundActivation())
+                    .Show();
+            }
+            catch (Exception ex)
+            {
+                new ToastContentBuilder()
+                    .AddText("Erreur lors de la capture d’écran")
+                    .AddText(ex.Message)
+                    .Show();
+            }
+        }
+
+        private static string SaveScreenshot(Bitmap bmp)
+        {
+            string picturesPath = Environment.GetFolderPath(Environment.SpecialFolder.MyPictures);
+            string directory = Path.Combine(picturesPath, "WannaTool_Captures");
+            if (!Directory.Exists(directory))
+                Directory.CreateDirectory(directory);
+
+            string fileName = $"Capture-WT_{DateTime.Now:yyyyMMdd_HHmmss}.png";
+            string filePath = Path.Combine(directory, fileName);
+
+            bmp.Save(filePath, ImageFormat.Png);
+            return filePath;
+        }
+
+        private static System.Windows.Media.Imaging.BitmapSource ToBitmapSource(this Bitmap source)
+        {
+            var hBitmap = source.GetHbitmap();
+            try
+            {
+                var bitmapSource = System.Windows.Interop.Imaging.CreateBitmapSourceFromHBitmap(
+                    hBitmap,
+                    IntPtr.Zero,
+                    Int32Rect.Empty,
+                    System.Windows.Media.Imaging.BitmapSizeOptions.FromEmptyOptions());
+                bitmapSource.Freeze();
+                return bitmapSource;
+            }
+            finally
+            {
+                DeleteObject(hBitmap);
+            }
+        }
+    }
+}

--- a/WannaTool/Classes/ScreenCaptureManager.cs
+++ b/WannaTool/Classes/ScreenCaptureManager.cs
@@ -65,20 +65,16 @@ namespace WannaTool
                     offsetX += screen.Bounds.Width;
                 }
 
-                // Copier dans le presse-papier (WPF Clipboard, évite la fuite mémoire)
                 System.Windows.Clipboard.SetImage(bmp.ToBitmapSource());
 
-                // Enregistrer l'image
                 var filePath = SaveScreenshot(bmp);
-
-                // Notification
-                new ToastContentBuilder()
-                    .AddText("Capture enregistrée")
-                    .AddText(allScreens ? "Tous les écrans ont été capturés." : "Écran principal capturé.")
+                    new ToastContentBuilder()
+                    .AddText("Screenshot saved")
+                    .AddText(allScreens ? "All screens captured." : "Primary screen captured.")
                     .AddArgument("action", "openScreenshot")
                     .AddArgument("path", filePath)
                     .AddButton(new ToastButton()
-                        .SetContent("Ouvrir")
+                        .SetContent("Open")
                         .AddArgument("action", "openScreenshot")
                         .AddArgument("path", filePath)
                         .SetBackgroundActivation())
@@ -87,7 +83,7 @@ namespace WannaTool
             catch (Exception ex)
             {
                 new ToastContentBuilder()
-                    .AddText("Erreur lors de la capture d’écran")
+                    .AddText("Error capturing screenshot")
                     .AddText(ex.Message)
                     .Show();
             }

--- a/WannaTool/Classes/SearchRedirects.cs
+++ b/WannaTool/Classes/SearchRedirects.cs
@@ -1,0 +1,54 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+
+namespace WannaTool
+{
+    public static class SearchRedirects
+    {
+        private static readonly Dictionary<string, string> EngineUrls = new(StringComparer.OrdinalIgnoreCase)
+        {
+            ["google"] = "https://www.google.com/search?q={0}",
+            ["bing"] = "https://www.bing.com/search?q={0}",
+            ["ddg"] = "https://duckduckgo.com/?q={0}",
+            ["brave"] = "https://search.brave.com/search?q={0}",
+            ["youtube"] = "https://www.youtube.com/results?search_query={0}",
+            ["wiki"] = "https://en.wikipedia.org/wiki/Special:Search?search={0}",
+            ["stackoverflow"] = "https://stackoverflow.com/search?q={0}",
+            ["youtube"] = "https://www.youtube.com/results?search_query={0}"
+        };
+
+        public static MainWindow.SearchResult? TryParseRedirect(string query)
+        {
+            if (string.IsNullOrWhiteSpace(query)) return null;
+
+            if (query.Trim().Equals("!help", StringComparison.OrdinalIgnoreCase))
+            {
+                return new MainWindow.SearchResult
+                {
+                    DisplayName = "WannaTool Help",
+                    FullPath = "!help"
+                };
+            }
+
+            int colon = query.IndexOf(':');
+            if (colon <= 0 || colon == query.Length - 1) return null;
+
+            string prefix = query.Substring(0, colon).ToLower();
+            string searchTerms = query[(colon + 1)..].Trim();
+
+            if (EngineUrls.TryGetValue(prefix, out var template) && !string.IsNullOrWhiteSpace(searchTerms))
+            {
+                string url = string.Format(template, Uri.EscapeDataString(searchTerms));
+                return new MainWindow.SearchResult
+                {
+                    DisplayName = $"Recherche {prefix} : \"{searchTerms}\"",
+                    FullPath = url
+                };
+            }
+
+            return null;
+        }
+    }
+}

--- a/WannaTool/Classes/SearchRedirects.cs
+++ b/WannaTool/Classes/SearchRedirects.cs
@@ -19,13 +19,13 @@ namespace WannaTool
             ["youtube"] = "https://www.youtube.com/results?search_query={0}"
         };
 
-        public static MainWindow.SearchResult? TryParseRedirect(string query)
+        public static SearchResult? TryParseRedirect(string query)
         {
             if (string.IsNullOrWhiteSpace(query)) return null;
 
             if (query.Trim().Equals("!help", StringComparison.OrdinalIgnoreCase))
             {
-                return new MainWindow.SearchResult
+                return new SearchResult
                 {
                     DisplayName = "WannaTool Help",
                     FullPath = "!help"
@@ -41,9 +41,9 @@ namespace WannaTool
             if (EngineUrls.TryGetValue(prefix, out var template) && !string.IsNullOrWhiteSpace(searchTerms))
             {
                 string url = string.Format(template, Uri.EscapeDataString(searchTerms));
-                return new MainWindow.SearchResult
+                return new SearchResult
                 {
-                    DisplayName = $"Recherche {prefix} : \"{searchTerms}\"",
+                    DisplayName = $"Redirect to {prefix} : \"{searchTerms}\"",
                     FullPath = url
                 };
             }

--- a/WannaTool/Classes/SearchRedirects.cs
+++ b/WannaTool/Classes/SearchRedirects.cs
@@ -32,6 +32,15 @@ namespace WannaTool
                 };
             }
 
+            if (query.Trim().Equals("!exit", StringComparison.OrdinalIgnoreCase))
+            {
+                return new SearchResult
+                {
+                    DisplayName = "Exit WannaTool",
+                    FullPath = "!exit"
+                };
+            }
+
             int colon = query.IndexOf(':');
             if (colon <= 0 || colon == query.Length - 1) return null;
 

--- a/WannaTool/Classes/SearchResult.cs
+++ b/WannaTool/Classes/SearchResult.cs
@@ -1,0 +1,32 @@
+using System.ComponentModel;
+using System.Windows.Media;
+
+namespace WannaTool
+{
+    public class SearchResult : INotifyPropertyChanged
+    {
+        public string DisplayName { get; set; } = "";
+        public string FullPath { get; set; } = "";
+        public bool IsFolder { get; set; }
+
+        private ImageSource? _icon;
+        public ImageSource? Icon
+        {
+            get
+            {
+                if (_icon == null)
+                    _icon = IconLoader.GetIcon(FullPath, IsFolder);
+                return _icon;
+            }
+        }
+
+        public override string ToString()
+        {
+            return DisplayName;
+        }
+
+        public event PropertyChangedEventHandler? PropertyChanged;
+        protected void OnPropertyChanged(string name) =>
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
+    }
+}

--- a/WannaTool/Classes/Utils.cs
+++ b/WannaTool/Classes/Utils.cs
@@ -1,0 +1,15 @@
+﻿using Microsoft.Toolkit.Uwp.Notifications;
+
+namespace WannaTool
+{
+    public static class Utils
+    {
+        public static void ShowToast(string title, string message, bool silent = false)
+        {
+            new ToastContentBuilder()
+                .AddText(title)
+                .AddText(message)
+                .Show();
+        }
+    }
+}

--- a/WannaTool/Docs/index.html
+++ b/WannaTool/Docs/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>WannaTool Help</title>
+    <title>WannaTool help page</title>
     <link rel="stylesheet" href="style.css" />
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -21,16 +21,16 @@
                 <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
                     <path stroke-linecap="round" stroke-linejoin="round" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
                 </svg>
-                Web Search & Redirects
+                Web search & redirects
             </h2>
             <ul>
                 <li>
                     <span class="command">google: query</span>
-                    <span class="description">Google Search</span>
+                    <span class="description">Google search</span>
                 </li>
                 <li>
                     <span class="command">bing: query</span>
-                    <span class="description">Bing Search</span>
+                    <span class="description">Bing search</span>
                 </li>
                 <li>
                     <span class="command">ddg: query</span>
@@ -38,7 +38,7 @@
                 </li>
                  <li>
                     <span class="command">brave: query</span>
-                    <span class="description">Brave Search</span>
+                    <span class="description">Brave search</span>
                 </li>
                 <li>
                     <span class="command">youtube: query</span>
@@ -50,7 +50,7 @@
                 </li>
                 <li>
                     <span class="command">stackoverflow: query</span>
-                    <span class="description">Stack Overflow</span>
+                    <span class="description">Stack overflow</span>
                 </li>
             </ul>
         </section>
@@ -60,7 +60,7 @@
                 <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
                     <path stroke-linecap="round" stroke-linejoin="round" d="M3 7v10a2 2 0 002 2h14a2 2 0 002-2V9a2 2 0 00-2-2h-6l-2-2H5a2 2 0 00-2 2z" />
                 </svg>
-                File Filters
+                File filters
             </h2>
             <ul>
                 <li>
@@ -69,11 +69,11 @@
                 </li>
                 <li>
                     <span class="command">pdf: name</span>
-                    <span class="description">PDF Documents</span>
+                    <span class="description">PDF documents</span>
                 </li>
                 <li>
                     <span class="command">doc: name</span>
-                    <span class="description">Word / Text Docs</span>
+                    <span class="description">Word / Text docs</span>
                 </li>
                 <li>
                     <span class="command">img: name</span>
@@ -81,7 +81,7 @@
                 </li>
                 <li>
                     <span class="command">code: name</span>
-                    <span class="description">Source Code</span>
+                    <span class="description">Source code</span>
                 </li>
             </ul>
         </section>
@@ -91,20 +91,24 @@
                 <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
                     <path stroke-linecap="round" stroke-linejoin="round" d="M9.75 17L9 20l-1 1h8l-1-1-.75-3M3 13h18M5 17h14a2 2 0 002-2V5a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" />
                 </svg>
-                System & Screenshots
+                System & screenshots
             </h2>
             <ul>
                 <li>
                     <span><kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>F5</kbd></span>
-                    <span class="description">Capture Primary</span>
+                    <span class="description">Capture primary screen</span>
                 </li>
                 <li>
                     <span><kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>F6</kbd></span>
-                    <span class="description">Capture All Screens</span>
+                    <span class="description">Capture all screens</span>
                 </li>
                 <li>
                     <span class="command">!help</span>
-                    <span class="description">Open Help</span>
+                    <span class="description">Open help</span>
+                </li>
+                <li>
+                    <span class="command">!exit</span>
+                    <span class="description">Exit WannaTool</span>
                 </li>
             </ul>
             <div style="margin-top: 1.5rem; padding-top: 1rem; border-top: 1px solid var(--card-border); font-size: 0.85rem; color: var(--text-secondary);">
@@ -118,14 +122,14 @@
                 <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
                     <path stroke-linecap="round" stroke-linejoin="round" d="M13 10V3L4 14h7v7l9-11h-7z" />
                 </svg>
-                Coming Soon
+                Coming soon
             </h2>
             <ul>
                 <li>
-                    <span class="description">Window Splitter</span>
+                    <span class="description">Window splitter</span>
                 </li>
                 <li>
-                    <span class="description">Clipboard History</span>
+                    <span class="description">Clipboard history</span>
                 </li>
                 <li>
                     <span class="description">Favorites</span>

--- a/WannaTool/Docs/index.html
+++ b/WannaTool/Docs/index.html
@@ -1,57 +1,147 @@
-﻿<!DOCTYPE html>
+<!DOCTYPE html>
 <html lang="en">
 <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>WannaTool - Help</title>
+    <title>WannaTool Help</title>
     <link rel="stylesheet" href="style.css" />
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;800&family=JetBrains+Mono:wght@500&display=swap" rel="stylesheet">
 </head>
 <body>
     <header>
-        <h1>WannaTool - Command Reference</h1>
-        <p>Your ultimate command launcher for Windows</p>
+        <h1>WannaTool</h1>
+        <p class="subtitle">The ultimate power user launcher for Windows</p>
     </header>
 
     <main>
         <section>
-            <h2>Search & Redirects</h2>
+            <h2>
+                <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                    <path stroke-linecap="round" stroke-linejoin="round" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
+                </svg>
+                Web Search & Redirects
+            </h2>
             <ul>
-                <li><strong>google: query</strong> – Search Google</li>
-                <li><strong>bing: query</strong> – Search Bing</li>
-                <li><strong>!help</strong> – Open this help page</li>
+                <li>
+                    <span class="command">google: query</span>
+                    <span class="description">Google Search</span>
+                </li>
+                <li>
+                    <span class="command">bing: query</span>
+                    <span class="description">Bing Search</span>
+                </li>
+                <li>
+                    <span class="command">ddg: query</span>
+                    <span class="description">DuckDuckGo</span>
+                </li>
+                 <li>
+                    <span class="command">brave: query</span>
+                    <span class="description">Brave Search</span>
+                </li>
+                <li>
+                    <span class="command">youtube: query</span>
+                    <span class="description">YouTube</span>
+                </li>
+                <li>
+                    <span class="command">wiki: query</span>
+                    <span class="description">Wikipedia</span>
+                </li>
+                <li>
+                    <span class="command">stackoverflow: query</span>
+                    <span class="description">Stack Overflow</span>
+                </li>
             </ul>
         </section>
 
         <section>
-            <h2>System Tools</h2>
+            <h2>
+                <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                    <path stroke-linecap="round" stroke-linejoin="round" d="M3 7v10a2 2 0 002 2h14a2 2 0 002-2V9a2 2 0 00-2-2h-6l-2-2H5a2 2 0 00-2 2z" />
+                </svg>
+                File Filters
+            </h2>
             <ul>
-                <li><strong>CTRL+SHIFT+F5</strong> – Screenshot primary screen</li>
-                <li><strong>CTRL+SHIFT+F6</strong> – Screenshot all screens</li>
-                <li>Screenshots are saved in <code>Images/WannaTool_Captures/</code></li>
+                <li>
+                    <span class="command">exe: name</span>
+                    <span class="description">Apps (.exe, .lnk)</span>
+                </li>
+                <li>
+                    <span class="command">pdf: name</span>
+                    <span class="description">PDF Documents</span>
+                </li>
+                <li>
+                    <span class="command">doc: name</span>
+                    <span class="description">Word / Text Docs</span>
+                </li>
+                <li>
+                    <span class="command">img: name</span>
+                    <span class="description">Images</span>
+                </li>
+                <li>
+                    <span class="command">code: name</span>
+                    <span class="description">Source Code</span>
+                </li>
             </ul>
         </section>
 
         <section>
-            <h2>Local File Features</h2>
+            <h2>
+                <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                    <path stroke-linecap="round" stroke-linejoin="round" d="M9.75 17L9 20l-1 1h8l-1-1-.75-3M3 13h18M5 17h14a2 2 0 002-2V5a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" />
+                </svg>
+                System & Screenshots
+            </h2>
             <ul>
-                <li><strong>pdf: name</strong> – Quickly open a PDF from your files</li>
-                <li><strong>img: name</strong> – Find and open images</li>
-                <li><strong>code: name</strong> – Locate source files</li>
+                <li>
+                    <span><kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>F5</kbd></span>
+                    <span class="description">Capture Primary</span>
+                </li>
+                <li>
+                    <span><kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>F6</kbd></span>
+                    <span class="description">Capture All Screens</span>
+                </li>
+                <li>
+                    <span class="command">!help</span>
+                    <span class="description">Open Help</span>
+                </li>
             </ul>
+            <div style="margin-top: 1.5rem; padding-top: 1rem; border-top: 1px solid var(--card-border); font-size: 0.85rem; color: var(--text-secondary);">
+                Screenshots saved to: <br>
+                <code style="color: #a5b4fc;">Pictures/WannaTool_Captures/</code>
+            </div>
         </section>
 
         <section>
-            <h2>Coming Soon</h2>
+            <h2>
+                <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                    <path stroke-linecap="round" stroke-linejoin="round" d="M13 10V3L4 14h7v7l9-11h-7z" />
+                </svg>
+                Coming Soon
+            </h2>
             <ul>
-                <li>Window splitter: position apps via text command</li>
-                <li>Clipboard manager with history</li>
-                <li>Favorites and shortcuts</li>
+                <li>
+                    <span class="description">Window Splitter</span>
+                </li>
+                <li>
+                    <span class="description">Clipboard History</span>
+                </li>
+                <li>
+                    <span class="description">Favorites</span>
+                </li>
+                <li>
+                    <span class="description">Themes</span>
+                </li>
             </ul>
         </section>
     </main>
 
     <footer>
-        <p>WannaTool by <strong>Kevin GREGOIRE</strong> – Open Source Project</p>
+        <p>WannaTool &copy; <span id="current-year"></span> &bull; Kevin GREGOIRE / Nodasys &bull; Open Source Project</p>
+        <script>
+            document.getElementById('current-year').textContent = new Date().getFullYear();
+        </script>
     </footer>
 </body>
 </html>

--- a/WannaTool/Docs/index.html
+++ b/WannaTool/Docs/index.html
@@ -1,0 +1,57 @@
+﻿<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>WannaTool - Help</title>
+    <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+    <header>
+        <h1>WannaTool - Command Reference</h1>
+        <p>Your ultimate command launcher for Windows</p>
+    </header>
+
+    <main>
+        <section>
+            <h2>Search & Redirects</h2>
+            <ul>
+                <li><strong>google: query</strong> – Search Google</li>
+                <li><strong>bing: query</strong> – Search Bing</li>
+                <li><strong>!help</strong> – Open this help page</li>
+            </ul>
+        </section>
+
+        <section>
+            <h2>System Tools</h2>
+            <ul>
+                <li><strong>CTRL+SHIFT+F5</strong> – Screenshot primary screen</li>
+                <li><strong>CTRL+SHIFT+F6</strong> – Screenshot all screens</li>
+                <li>Screenshots are saved in <code>Images/WannaTool_Captures/</code></li>
+            </ul>
+        </section>
+
+        <section>
+            <h2>Local File Features</h2>
+            <ul>
+                <li><strong>pdf: name</strong> – Quickly open a PDF from your files</li>
+                <li><strong>img: name</strong> – Find and open images</li>
+                <li><strong>code: name</strong> – Locate source files</li>
+            </ul>
+        </section>
+
+        <section>
+            <h2>Coming Soon</h2>
+            <ul>
+                <li>Window splitter: position apps via text command</li>
+                <li>Clipboard manager with history</li>
+                <li>Favorites and shortcuts</li>
+            </ul>
+        </section>
+    </main>
+
+    <footer>
+        <p>WannaTool by <strong>Kevin GREGOIRE</strong> – Open Source Project</p>
+    </footer>
+</body>
+</html>

--- a/WannaTool/Docs/style.css
+++ b/WannaTool/Docs/style.css
@@ -1,0 +1,55 @@
+body {
+    font-family: 'Segoe UI', sans-serif;
+    background-color: #1e1e1e;
+    color: #ddd;
+    margin: 0;
+    padding: 0;
+}
+
+header {
+    background: #333;
+    padding: 2em;
+    text-align: center;
+    color: white;
+}
+
+main {
+    max-width: 800px;
+    margin: 2em auto;
+    padding: 0 2em;
+}
+
+h1, h2 {
+    color: #61dafb;
+}
+
+ul {
+    list-style: none;
+    padding-left: 1em;
+}
+
+    ul li::before {
+        content: '›';
+        color: #61dafb;
+        margin-right: 0.5em;
+    }
+
+section {
+    margin-bottom: 2em;
+}
+
+code {
+    background-color: #2d2d2d;
+    padding: 2px 6px;
+    border-radius: 4px;
+    font-family: Consolas, monospace;
+    font-size: 0.95em;
+}
+
+footer {
+    background: #2a2a2a;
+    color: #aaa;
+    text-align: center;
+    padding: 1em;
+    font-size: 0.9em;
+}

--- a/WannaTool/Docs/style.css
+++ b/WannaTool/Docs/style.css
@@ -1,55 +1,164 @@
-body {
-    font-family: 'Segoe UI', sans-serif;
-    background-color: #1e1e1e;
-    color: #ddd;
+:root {
+    --bg-color: #0f0f13;
+    --text-primary: #ffffff;
+    --text-secondary: #a0a0a0;
+    --accent-color: #6366f1;
+    --accent-hover: #4f46e5;
+    --card-bg: rgba(30, 30, 35, 0.6);
+    --card-border: rgba(255, 255, 255, 0.1);
+    --glass-blur: 12px;
+    --font-stack: 'Inter', -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+}
+
+* {
+    box-sizing: border-box;
     margin: 0;
     padding: 0;
 }
 
+body {
+    font-family: var(--font-stack);
+    background-color: var(--bg-color);
+    background-image: 
+        radial-gradient(circle at 15% 50%, rgba(99, 102, 241, 0.15) 0%, transparent 25%),
+        radial-gradient(circle at 85% 30%, rgba(139, 92, 246, 0.15) 0%, transparent 25%);
+    color: var(--text-primary);
+    line-height: 1.6;
+    min-height: 100vh;
+}
+
 header {
-    background: #333;
-    padding: 2em;
     text-align: center;
-    color: white;
+    padding: 4rem 2rem 2rem;
+    animation: fadeInDown 0.8s ease-out;
+}
+
+h1 {
+    font-size: 3.5rem;
+    font-weight: 800;
+    letter-spacing: -0.02em;
+    background: linear-gradient(to right, #fff, #a5b4fc);
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent;
+    margin-bottom: 0.5rem;
+}
+
+.subtitle {
+    font-size: 1.2rem;
+    color: var(--text-secondary);
+    font-weight: 400;
 }
 
 main {
-    max-width: 800px;
-    margin: 2em auto;
-    padding: 0 2em;
+    max-width: 1200px;
+    margin: 0 auto;
+    padding: 2rem;
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(350px, 1fr));
+    gap: 2rem;
+    animation: fadeInUp 0.8s ease-out 0.2s backwards;
 }
 
-h1, h2 {
-    color: #61dafb;
+section {
+    background: var(--card-bg);
+    backdrop-filter: blur(var(--glass-blur));
+    -webkit-backdrop-filter: blur(var(--glass-blur));
+    border: 1px solid var(--card-border);
+    border-radius: 16px;
+    padding: 2rem;
+    transition: transform 0.3s ease, box-shadow 0.3s ease, border-color 0.3s ease;
+}
+
+section:hover {
+    transform: translateY(-5px);
+    box-shadow: 0 20px 40px rgba(0, 0, 0, 0.4);
+    border-color: rgba(99, 102, 241, 0.3);
+}
+
+h2 {
+    font-size: 1.5rem;
+    margin-bottom: 1.5rem;
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    color: #fff;
+    border-bottom: 1px solid var(--card-border);
+    padding-bottom: 1rem;
+}
+
+h2 svg {
+    width: 24px;
+    height: 24px;
+    color: var(--accent-color);
 }
 
 ul {
     list-style: none;
-    padding-left: 1em;
 }
 
-    ul li::before {
-        content: '›';
-        color: #61dafb;
-        margin-right: 0.5em;
-    }
-
-section {
-    margin-bottom: 2em;
+li {
+    margin-bottom: 1rem;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
 }
 
-code {
-    background-color: #2d2d2d;
-    padding: 2px 6px;
-    border-radius: 4px;
-    font-family: Consolas, monospace;
-    font-size: 0.95em;
+.command-wrapper {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+}
+
+.command {
+    font-family: 'JetBrains Mono', 'Consolas', monospace;
+    font-size: 0.9rem;
+    color: #a5b4fc;
+    background: rgba(99, 102, 241, 0.1);
+    padding: 0.25rem 0.6rem;
+    border-radius: 6px;
+    border: 1px solid rgba(99, 102, 241, 0.2);
+    white-space: nowrap;
+}
+
+.description {
+    font-size: 0.95rem;
+    color: var(--text-secondary);
+    text-align: right;
+}
+
+kbd {
+    background: #2a2a30;
+    border: 1px solid #3f3f46;
+    border-radius: 6px;
+    padding: 0.2rem 0.5rem;
+    font-family: inherit;
+    font-size: 0.85rem;
+    color: #e4e4e7;
+    box-shadow: 0 2px 0 #18181b;
 }
 
 footer {
-    background: #2a2a2a;
-    color: #aaa;
     text-align: center;
-    padding: 1em;
-    font-size: 0.9em;
+    padding: 3rem;
+    color: #52525b;
+    font-size: 0.9rem;
+    margin-top: auto;
+}
+
+@keyframes fadeInDown {
+    from { opacity: 0; transform: translateY(-20px); }
+    to { opacity: 1; transform: translateY(0); }
+}
+
+@keyframes fadeInUp {
+    from { opacity: 0; transform: translateY(20px); }
+    to { opacity: 1; transform: translateY(0); }
+}
+
+@media (max-width: 768px) {
+    h1 { font-size: 2.5rem; }
+    main { grid-template-columns: 1fr; }
+    li { flex-direction: column; align-items: flex-start; gap: 0.25rem; }
+    .description { text-align: left; }
 }

--- a/WannaTool/MainWindow.xaml
+++ b/WannaTool/MainWindow.xaml
@@ -12,15 +12,46 @@
         Background="Transparent"
         ShowInTaskbar="False"
         Topmost="True"
-        Width="800" Height="600"
+        Width="700"
+        SizeToContent="Height"
         ResizeMode="NoResize">
 
     <Window.Resources>
         <BooleanToVisibilityConverter x:Key="BoolToVis" />
         
+        <Style x:Key="ModernScrollBar" TargetType="{x:Type ScrollBar}">
+            <Setter Property="Stylus.IsPressAndHoldEnabled" Value="false"/>
+            <Setter Property="Stylus.IsFlicksEnabled" Value="false"/>
+            <Setter Property="Background" Value="Transparent"/>
+            <Setter Property="Width" Value="8"/>
+            <Setter Property="Template">
+                <Setter.Value>
+                    <ControlTemplate TargetType="{x:Type ScrollBar}">
+                        <Grid x:Name="Bg" SnapsToDevicePixels="true">
+                            <Track x:Name="PART_Track" IsDirectionReversed="true">
+                                <Track.Thumb>
+                                    <Thumb Style="{DynamicResource ScrollThumbStyle}"/>
+                                </Track.Thumb>
+                            </Track>
+                        </Grid>
+                    </ControlTemplate>
+                </Setter.Value>
+            </Setter>
+        </Style>
+
+        <Style x:Key="ScrollThumbStyle" TargetType="{x:Type Thumb}">
+            <Setter Property="Template">
+                <Setter.Value>
+                    <ControlTemplate TargetType="{x:Type Thumb}">
+                        <Border Background="#44FFFFFF" CornerRadius="4" Margin="2,0"/>
+                    </ControlTemplate>
+                </Setter.Value>
+            </Setter>
+        </Style>
+
         <Style x:Key="ResultItemStyle" TargetType="ListBoxItem">
             <Setter Property="Background" Value="Transparent"/>
-            <Setter Property="Padding" Value="10,5"/>
+            <Setter Property="Padding" Value="12,8"/>
             <Setter Property="BorderThickness" Value="0"/>
             <Setter Property="Template">
                 <Setter.Value>
@@ -30,18 +61,18 @@
                                 BorderBrush="{TemplateBinding BorderBrush}" 
                                 BorderThickness="{TemplateBinding BorderThickness}" 
                                 Padding="{TemplateBinding Padding}" 
-                                CornerRadius="4"
-                                Margin="2">
+                                CornerRadius="6"
+                                Margin="0,1">
                             <ContentPresenter HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}" 
                                               VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
                                               SnapsToDevicePixels="true"/>
                         </Border>
                         <ControlTemplate.Triggers>
                             <Trigger Property="IsMouseOver" Value="True">
-                                <Setter TargetName="Bd" Property="Background" Value="#33FFFFFF"/>
+                                <Setter TargetName="Bd" Property="Background" Value="#1FFFFFFF"/>
                             </Trigger>
                             <Trigger Property="IsSelected" Value="True">
-                                <Setter TargetName="Bd" Property="Background" Value="#66FFFFFF"/>
+                                <Setter TargetName="Bd" Property="Background" Value="#3FFFFFFF"/>
                             </Trigger>
                         </ControlTemplate.Triggers>
                     </ControlTemplate>
@@ -50,70 +81,72 @@
         </Style>
     </Window.Resources>
 
-    <Grid>
-        <Border Background="#CC202020" CornerRadius="12" Margin="20">
+    <Grid VerticalAlignment="Top">
+        <Border Background="#E618181B" 
+                CornerRadius="12" 
+                BorderBrush="#33FFFFFF" 
+                BorderThickness="1"
+                Margin="20">
             <Border.Effect>
-                <DropShadowEffect Color="Black" BlurRadius="20" ShadowDepth="5" Opacity="0.4" />
+                <DropShadowEffect Color="Black" BlurRadius="30" ShadowDepth="10" Opacity="0.5" />
             </Border.Effect>
             
-            <Grid Margin="10">
-                <Grid.RowDefinitions>
-                    <RowDefinition Height="Auto" />
-                    <RowDefinition Height="*" />
-                </Grid.RowDefinitions>
+            <StackPanel Margin="0">
+                <Grid Height="60">
+                    <TextBlock Text="Type to search..." 
+                               VerticalAlignment="Center" 
+                               Margin="20,0" 
+                               Foreground="#66FFFFFF"
+                               FontSize="20"
+                               IsHitTestVisible="False">
+                        <TextBlock.Style>
+                            <Style TargetType="TextBlock">
+                                <Setter Property="Visibility" Value="Collapsed"/>
+                                <Style.Triggers>
+                                    <DataTrigger Binding="{Binding Text, ElementName=SearchBox}" Value="">
+                                        <Setter Property="Visibility" Value="Visible"/>
+                                    </DataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </TextBlock.Style>
+                    </TextBlock>
+                    
+                    <TextBox x:Name="SearchBox"
+                             Text="{Binding SearchText, UpdateSourceTrigger=PropertyChanged}"
+                             Background="Transparent"
+                             BorderThickness="0"
+                             FontSize="20"
+                             Foreground="White"
+                             VerticalContentAlignment="Center"
+                             Padding="20,0"
+                             CaretBrush="White">
+                        <TextBox.InputBindings>
+                            <KeyBinding Key="Enter" Command="{Binding ExecuteCommand}" />
+                            <KeyBinding Key="Down" Command="{Binding NextResultCommand}" />
+                            <KeyBinding Key="Up" Command="{Binding PreviousResultCommand}" />
+                            <KeyBinding Key="Esc" Command="{Binding ExitCommand}" />
+                        </TextBox.InputBindings>
+                    </TextBox>
+                </Grid>
 
-                <Border Grid.Row="0" 
-                        Background="#33FFFFFF" 
-                        CornerRadius="8" 
-                        Height="50" 
-                        Margin="0,0,0,10">
-                    <Grid>
-                        <TextBlock Text="Type to search..." 
-                                   VerticalAlignment="Center" 
-                                   Margin="15,0" 
-                                   Foreground="#88FFFFFF"
-                                   FontSize="18"
-                                   IsHitTestVisible="False">
-                            <TextBlock.Style>
-                                <Style TargetType="TextBlock">
-                                    <Setter Property="Visibility" Value="Collapsed"/>
-                                    <Style.Triggers>
-                                        <DataTrigger Binding="{Binding Text, ElementName=SearchBox}" Value="">
-                                            <Setter Property="Visibility" Value="Visible"/>
-                                        </DataTrigger>
-                                    </Style.Triggers>
-                                </Style>
-                            </TextBlock.Style>
-                        </TextBlock>
-                        
-                        <TextBox x:Name="SearchBox"
-                                 Text="{Binding SearchText, UpdateSourceTrigger=PropertyChanged}"
-                                 Background="Transparent"
-                                 BorderThickness="0"
-                                 FontSize="18"
-                                 Foreground="White"
-                                 VerticalContentAlignment="Center"
-                                 Padding="15,0"
-                                 CaretBrush="White">
-                            <TextBox.InputBindings>
-                                <KeyBinding Key="Enter" Command="{Binding ExecuteCommand}" />
-                                <KeyBinding Key="Down" Command="{Binding NextResultCommand}" />
-                                <KeyBinding Key="Up" Command="{Binding PreviousResultCommand}" />
-                            </TextBox.InputBindings>
-                        </TextBox>
-                    </Grid>
-                </Border>
+                <Border Height="1" Background="#1FFFFFFF" 
+                        Visibility="{Binding HasResults, Converter={StaticResource BoolToVis}}" />
 
-                <ListBox Grid.Row="1" 
-                         ItemsSource="{Binding Results}" 
+                <ListBox ItemsSource="{Binding Results}" 
                          SelectedItem="{Binding SelectedResult}"
                          Background="Transparent"
                          BorderThickness="0"
+                         MaxHeight="400"
                          ScrollViewer.HorizontalScrollBarVisibility="Disabled"
                          ScrollViewer.VerticalScrollBarVisibility="Auto"
                          ItemContainerStyle="{StaticResource ResultItemStyle}"
                          VirtualizingStackPanel.IsVirtualizing="True"
-                         VirtualizingStackPanel.VirtualizationMode="Recycling">
+                         VirtualizingStackPanel.VirtualizationMode="Recycling"
+                         Visibility="{Binding HasResults, Converter={StaticResource BoolToVis}}"
+                         Padding="8">
+                    <ListBox.Resources>
+                        <Style TargetType="{x:Type ScrollBar}" BasedOn="{StaticResource ModernScrollBar}"/>
+                    </ListBox.Resources>
                     <ListBox.ItemTemplate>
                         <DataTemplate>
                             <Grid>
@@ -122,11 +155,11 @@
                                     <ColumnDefinition Width="*"/>
                                 </Grid.ColumnDefinitions>
                                 
-                                <Image Grid.Column="0" Source="{Binding Icon}" Width="32" Height="32" Margin="0,0,10,0"/>
+                                <Image Grid.Column="0" Source="{Binding Icon}" Width="24" Height="24" Margin="0,0,12,0"/>
                                 
                                 <StackPanel Grid.Column="1" VerticalAlignment="Center">
-                                    <TextBlock Text="{Binding DisplayName}" FontSize="16" Foreground="White" FontWeight="SemiBold"/>
-                                    <TextBlock Text="{Binding FullPath}" FontSize="12" Foreground="#AAFFFFFF" TextTrimming="CharacterEllipsis"/>
+                                    <TextBlock Text="{Binding DisplayName}" FontSize="15" Foreground="#EEEEEE" FontWeight="Medium"/>
+                                    <TextBlock Text="{Binding FullPath}" FontSize="12" Foreground="#88FFFFFF" TextTrimming="CharacterEllipsis"/>
                                 </StackPanel>
 
                                 <Grid.InputBindings>
@@ -144,7 +177,7 @@
                         </DataTemplate>
                     </ListBox.ItemTemplate>
                 </ListBox>
-            </Grid>
+            </StackPanel>
         </Border>
     </Grid>
 </Window>

--- a/WannaTool/MainWindow.xaml
+++ b/WannaTool/MainWindow.xaml
@@ -1,145 +1,150 @@
-﻿<Window x:Class="WannaTool.MainWindow"
-       xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-       Title="WannaTool"
-       WindowStartupLocation="CenterScreen"
-       WindowStyle="None"
-       AllowsTransparency="True"
-       Background="Transparent"
-       ShowInTaskbar="False"
-       Topmost="True"
-       Width="800" Height="300">
+<Window x:Class="WannaTool.MainWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:local="clr-namespace:WannaTool"
+        mc:Ignorable="d"
+        Title="WannaTool"
+        WindowStartupLocation="CenterScreen"
+        WindowStyle="None"
+        AllowsTransparency="True"
+        Background="Transparent"
+        ShowInTaskbar="False"
+        Topmost="True"
+        Width="800" Height="600"
+        ResizeMode="NoResize">
 
-   <Grid Background="Transparent">
-       <!-- Fond semi-transparent -->
-       <Grid Background="#80000000">
+    <Window.Resources>
+        <BooleanToVisibilityConverter x:Key="BoolToVis" />
+        
+        <Style x:Key="ResultItemStyle" TargetType="ListBoxItem">
+            <Setter Property="Background" Value="Transparent"/>
+            <Setter Property="Padding" Value="10,5"/>
+            <Setter Property="BorderThickness" Value="0"/>
+            <Setter Property="Template">
+                <Setter.Value>
+                    <ControlTemplate TargetType="ListBoxItem">
+                        <Border x:Name="Bd" 
+                                Background="{TemplateBinding Background}" 
+                                BorderBrush="{TemplateBinding BorderBrush}" 
+                                BorderThickness="{TemplateBinding BorderThickness}" 
+                                Padding="{TemplateBinding Padding}" 
+                                CornerRadius="4"
+                                Margin="2">
+                            <ContentPresenter HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}" 
+                                              VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                                              SnapsToDevicePixels="true"/>
+                        </Border>
+                        <ControlTemplate.Triggers>
+                            <Trigger Property="IsMouseOver" Value="True">
+                                <Setter TargetName="Bd" Property="Background" Value="#33FFFFFF"/>
+                            </Trigger>
+                            <Trigger Property="IsSelected" Value="True">
+                                <Setter TargetName="Bd" Property="Background" Value="#66FFFFFF"/>
+                            </Trigger>
+                        </ControlTemplate.Triggers>
+                    </ControlTemplate>
+                </Setter.Value>
+            </Setter>
+        </Style>
+    </Window.Resources>
 
-           <!-- Barre de recherche -->
-           <Border 
-               Background="#CC333333" 
-               CornerRadius="15" 
-               HorizontalAlignment="Center" 
-               VerticalAlignment="Top"
-               Width="600" Height="50"
-               Margin="0,30,0,0"
-               Padding="10">
+    <Grid>
+        <Border Background="#CC202020" CornerRadius="12" Margin="20">
+            <Border.Effect>
+                <DropShadowEffect Color="Black" BlurRadius="20" ShadowDepth="5" Opacity="0.4" />
+            </Border.Effect>
+            
+            <Grid Margin="10">
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto" />
+                    <RowDefinition Height="*" />
+                </Grid.RowDefinitions>
 
-               <Border.Effect>
-                   <DropShadowEffect 
-                       Color="Black" 
-                       BlurRadius="20" 
-                       Opacity="0.5" 
-                       ShadowDepth="5" />
-               </Border.Effect>
+                <Border Grid.Row="0" 
+                        Background="#33FFFFFF" 
+                        CornerRadius="8" 
+                        Height="50" 
+                        Margin="0,0,0,10">
+                    <Grid>
+                        <TextBlock Text="Type to search..." 
+                                   VerticalAlignment="Center" 
+                                   Margin="15,0" 
+                                   Foreground="#88FFFFFF"
+                                   FontSize="18"
+                                   IsHitTestVisible="False">
+                            <TextBlock.Style>
+                                <Style TargetType="TextBlock">
+                                    <Setter Property="Visibility" Value="Collapsed"/>
+                                    <Style.Triggers>
+                                        <DataTrigger Binding="{Binding Text, ElementName=SearchBox}" Value="">
+                                            <Setter Property="Visibility" Value="Visible"/>
+                                        </DataTrigger>
+                                    </Style.Triggers>
+                                </Style>
+                            </TextBlock.Style>
+                        </TextBlock>
+                        
+                        <TextBox x:Name="SearchBox"
+                                 Text="{Binding SearchText, UpdateSourceTrigger=PropertyChanged}"
+                                 Background="Transparent"
+                                 BorderThickness="0"
+                                 FontSize="18"
+                                 Foreground="White"
+                                 VerticalContentAlignment="Center"
+                                 Padding="15,0"
+                                 CaretBrush="White">
+                            <TextBox.InputBindings>
+                                <KeyBinding Key="Enter" Command="{Binding ExecuteCommand}" />
+                                <KeyBinding Key="Down" Command="{Binding NextResultCommand}" />
+                                <KeyBinding Key="Up" Command="{Binding PreviousResultCommand}" />
+                            </TextBox.InputBindings>
+                        </TextBox>
+                    </Grid>
+                </Border>
 
-                <TextBox Name="SearchBox"
-                        FontSize="18"
-                        Background="Transparent"
-                        BorderThickness="0"
-                        Foreground="White"
-                        VerticalContentAlignment="Center"
-                        HorizontalContentAlignment="Left"
-                        Margin="5,0"
-                        TextChanged="SearchBox_TextChanged"
-                        KeyDown="SearchBox_KeyDown">
-                    <TextBox.Style>
-                       <Style TargetType="TextBox">
-                           <Setter Property="Template">
-                               <Setter.Value>
-                                   <ControlTemplate TargetType="TextBox">
-                                       <Grid>
-                                           <TextBox Text="{Binding Text, RelativeSource={RelativeSource TemplatedParent}, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
-                                                    Background="Transparent"
-                                                    BorderThickness="0"
-                                                    Foreground="White"
-                                                    CaretBrush="White"
-                                                    VerticalContentAlignment="Center"
-                                                    HorizontalContentAlignment="Left" />
-                                           <TextBlock Text="Rechercher..."
-                                                      Foreground="Gray"
-                                                      VerticalAlignment="Center"
-                                                      HorizontalAlignment="Left"
-                                                      Margin="5,0"
-                                                      IsHitTestVisible="False"
-                                                      Visibility="{Binding Text, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource StringNotNullOrEmptyToVisibilityConverter}}" />
-                                       </Grid>
-                                   </ControlTemplate>
-                               </Setter.Value>
-                           </Setter>
-                       </Style>
-                   </TextBox.Style>
-                </TextBox>
+                <ListBox Grid.Row="1" 
+                         ItemsSource="{Binding Results}" 
+                         SelectedItem="{Binding SelectedResult}"
+                         Background="Transparent"
+                         BorderThickness="0"
+                         ScrollViewer.HorizontalScrollBarVisibility="Disabled"
+                         ScrollViewer.VerticalScrollBarVisibility="Auto"
+                         ItemContainerStyle="{StaticResource ResultItemStyle}"
+                         VirtualizingStackPanel.IsVirtualizing="True"
+                         VirtualizingStackPanel.VirtualizationMode="Recycling">
+                    <ListBox.ItemTemplate>
+                        <DataTemplate>
+                            <Grid>
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="Auto"/>
+                                    <ColumnDefinition Width="*"/>
+                                </Grid.ColumnDefinitions>
+                                
+                                <Image Grid.Column="0" Source="{Binding Icon}" Width="32" Height="32" Margin="0,0,10,0"/>
+                                
+                                <StackPanel Grid.Column="1" VerticalAlignment="Center">
+                                    <TextBlock Text="{Binding DisplayName}" FontSize="16" Foreground="White" FontWeight="SemiBold"/>
+                                    <TextBlock Text="{Binding FullPath}" FontSize="12" Foreground="#AAFFFFFF" TextTrimming="CharacterEllipsis"/>
+                                </StackPanel>
 
-           </Border>
-
-           <!-- Liste des résultats -->
-           <ListBox x:Name="ResultsList"
-                    Width="600"
-                    Margin="100,100,100,20"
-                    HorizontalAlignment="Center"
-                    VerticalAlignment="Top"
-                    Background="#CC333333"
-                    Foreground="White"
-                    BorderBrush="White"
-                    BorderThickness="0"
-                    Visibility="Collapsed"
-                    FontSize="16"
-                    ScrollViewer.VerticalScrollBarVisibility="Hidden"
-                    ScrollViewer.HorizontalScrollBarVisibility="Disabled"
-                    KeyDown="ResultsList_KeyDown">
-               <ListBox.Resources>
-                   <Style TargetType="{x:Type ScrollBar}">
-                       <Setter Property="Width" Value="8"/>
-                       <Setter Property="Background" Value="Transparent"/>
-                       <Setter Property="Foreground" Value="#66FFFFFF"/>
-                   </Style>
-                   <DataTemplate x:Key="ResultTemplate">
-                       <Border>
-                           <StackPanel Orientation="Horizontal" Margin="5">
-                               <Image Source="{Binding Icon}" Width="24" Height="24" Margin="0,0,10,0" VerticalAlignment="Center"/>
-                               <StackPanel Orientation="Vertical" Margin="5">
-                                   <TextBlock Text="{Binding DisplayName}" 
-                              FontSize="16" 
-                              Foreground="White"
-                              VerticalAlignment="Center"
-                              TextTrimming="CharacterEllipsis"/>
-                                   <TextBlock Text="{Binding FullPath}" 
-                              FontSize="12" 
-                              Foreground="Gray" 
-                              TextTrimming="CharacterEllipsis"
-                              TextWrapping="NoWrap"
-                              MaxWidth="500"
-                              Margin="0,2,0,0"/>
-                               </StackPanel>
-                           </StackPanel>
-                           <Border.ContextMenu>
-                               <ContextMenu>
-                                   <MenuItem Header="Ouvrir" Click="OpenFile_Click"/>
-                                   <MenuItem Header="Ouvrir l'emplacement" Click="OpenLocation_Click"/>
-                                   <MenuItem Header="Copier le chemin" Click="CopyPath_Click"/>
-                                   <Separator />
-                                   <MenuItem Header="Supprimer" Click="DeleteFile_Click"/>
-                                   <MenuItem Header="Renommer" Click="RenameFile_Click"/>
-                                   <Separator />
-                                   <MenuItem Header="Propriétés" Click="ShowProperties_Click"/>
-                               </ContextMenu>
-                           </Border.ContextMenu>
-                       </Border>
-                   </DataTemplate>
-               </ListBox.Resources>
-               <ListBox.ItemTemplate>
-                   <StaticResource ResourceKey="ResultTemplate"/>
-               </ListBox.ItemTemplate>
-           </ListBox>
-       </Grid>
-        <TextBlock x:Name="LoadingIndicator"
-          Text="Indexation en cours..."
-          Foreground="White"
-          FontSize="16"
-          HorizontalAlignment="Center"
-          VerticalAlignment="Top"
-          Margin="0,20,0,0"
-          Visibility="Collapsed"
-          />
+                                <Grid.InputBindings>
+                                    <MouseBinding Gesture="LeftDoubleClick" Command="{Binding DataContext.ExecuteCommand, RelativeSource={RelativeSource AncestorType=Window}}" CommandParameter="{Binding}" />
+                                </Grid.InputBindings>
+                                
+                                <Grid.ContextMenu>
+                                    <ContextMenu>
+                                        <MenuItem Header="Open" Command="{Binding DataContext.ExecuteCommand, RelativeSource={RelativeSource AncestorType=Window}}" CommandParameter="{Binding}" />
+                                        <MenuItem Header="Open File Location" Command="{Binding DataContext.OpenLocationCommand, RelativeSource={RelativeSource AncestorType=Window}}" CommandParameter="{Binding}" />
+                                        <MenuItem Header="Copy Path" Command="{Binding DataContext.CopyPathCommand, RelativeSource={RelativeSource AncestorType=Window}}" CommandParameter="{Binding}" />
+                                    </ContextMenu>
+                                </Grid.ContextMenu>
+                            </Grid>
+                        </DataTemplate>
+                    </ListBox.ItemTemplate>
+                </ListBox>
+            </Grid>
+        </Border>
     </Grid>
 </Window>

--- a/WannaTool/MainWindow.xaml
+++ b/WannaTool/MainWindow.xaml
@@ -1,144 +1,145 @@
 ﻿<Window x:Class="WannaTool.MainWindow"
-        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        Title="WannaTool"
-        WindowStartupLocation="CenterScreen"
-        WindowStyle="None"
-        AllowsTransparency="True"
-        Background="Transparent"
-        ShowInTaskbar="False"
-        Topmost="True"
-        Width="800" Height="300">
+       xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+       Title="WannaTool"
+       WindowStartupLocation="CenterScreen"
+       WindowStyle="None"
+       AllowsTransparency="True"
+       Background="Transparent"
+       ShowInTaskbar="False"
+       Topmost="True"
+       Width="800" Height="300">
 
-    <Grid Background="Transparent">
-        <!-- Fond semi-transparent -->
-        <Grid Background="#80000000">
+   <Grid Background="Transparent">
+       <!-- Fond semi-transparent -->
+       <Grid Background="#80000000">
 
-            <!-- Barre de recherche -->
-            <Border 
-                Background="#CC333333" 
-                CornerRadius="15" 
-                HorizontalAlignment="Center" 
-                VerticalAlignment="Top"
-                Width="600" Height="50"
-                Margin="0,30,0,0"
-                Padding="10">
+           <!-- Barre de recherche -->
+           <Border 
+               Background="#CC333333" 
+               CornerRadius="15" 
+               HorizontalAlignment="Center" 
+               VerticalAlignment="Top"
+               Width="600" Height="50"
+               Margin="0,30,0,0"
+               Padding="10">
 
-                <Border.Effect>
-                    <DropShadowEffect 
-                        Color="Black" 
-                        BlurRadius="20" 
-                        Opacity="0.5" 
-                        ShadowDepth="5" />
-                </Border.Effect>
+               <Border.Effect>
+                   <DropShadowEffect 
+                       Color="Black" 
+                       BlurRadius="20" 
+                       Opacity="0.5" 
+                       ShadowDepth="5" />
+               </Border.Effect>
 
                 <TextBox Name="SearchBox"
-                         FontSize="18"
-                         Background="Transparent"
-                         BorderThickness="0"
-                         Foreground="White"
-                         VerticalContentAlignment="Center"
-                         HorizontalContentAlignment="Left"
-                         Margin="5,0"
-                         TextChanged="SearchBox_TextChanged">
+                        FontSize="18"
+                        Background="Transparent"
+                        BorderThickness="0"
+                        Foreground="White"
+                        VerticalContentAlignment="Center"
+                        HorizontalContentAlignment="Left"
+                        Margin="5,0"
+                        TextChanged="SearchBox_TextChanged"
+                        KeyDown="SearchBox_KeyDown">
                     <TextBox.Style>
-                        <Style TargetType="TextBox">
-                            <Setter Property="Template">
-                                <Setter.Value>
-                                    <ControlTemplate TargetType="TextBox">
-                                        <Grid>
-                                            <TextBox Text="{Binding Text, RelativeSource={RelativeSource TemplatedParent}, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
-                                                     Background="Transparent"
-                                                     BorderThickness="0"
-                                                     Foreground="White"
-                                                     CaretBrush="White"
-                                                     VerticalContentAlignment="Center"
-                                                     HorizontalContentAlignment="Left" />
-                                            <TextBlock Text="Rechercher..."
-                                                       Foreground="Gray"
-                                                       VerticalAlignment="Center"
-                                                       HorizontalAlignment="Left"
-                                                       Margin="5,0"
-                                                       IsHitTestVisible="False"
-                                                       Visibility="{Binding Text, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource StringNotNullOrEmptyToVisibilityConverter}}" />
-                                        </Grid>
-                                    </ControlTemplate>
-                                </Setter.Value>
-                            </Setter>
-                        </Style>
-                    </TextBox.Style>
+                       <Style TargetType="TextBox">
+                           <Setter Property="Template">
+                               <Setter.Value>
+                                   <ControlTemplate TargetType="TextBox">
+                                       <Grid>
+                                           <TextBox Text="{Binding Text, RelativeSource={RelativeSource TemplatedParent}, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                                                    Background="Transparent"
+                                                    BorderThickness="0"
+                                                    Foreground="White"
+                                                    CaretBrush="White"
+                                                    VerticalContentAlignment="Center"
+                                                    HorizontalContentAlignment="Left" />
+                                           <TextBlock Text="Rechercher..."
+                                                      Foreground="Gray"
+                                                      VerticalAlignment="Center"
+                                                      HorizontalAlignment="Left"
+                                                      Margin="5,0"
+                                                      IsHitTestVisible="False"
+                                                      Visibility="{Binding Text, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource StringNotNullOrEmptyToVisibilityConverter}}" />
+                                       </Grid>
+                                   </ControlTemplate>
+                               </Setter.Value>
+                           </Setter>
+                       </Style>
+                   </TextBox.Style>
                 </TextBox>
 
-            </Border>
+           </Border>
 
-            <!-- Liste des résultats -->
-            <ListBox x:Name="ResultsList"
-         Width="600"
-         Margin="100,100,100,20"
-         HorizontalAlignment="Center"
-         VerticalAlignment="Top"
-         Background="#CC333333"
-         Foreground="White"
-         BorderBrush="White"
-         BorderThickness="0"
-         Visibility="Collapsed"
-         MouseDoubleClick="ResultsList_MouseDoubleClick"
-         FontSize="16"
-         ScrollViewer.VerticalScrollBarVisibility="Auto"
-         ScrollViewer.HorizontalScrollBarVisibility="Disabled">
-                <ListBox.Resources>
-                    <Style TargetType="{x:Type ScrollBar}">
-                        <Setter Property="Width" Value="8"/>
-                        <Setter Property="Background" Value="Transparent"/>
-                        <Setter Property="Foreground" Value="#66FFFFFF"/>
-                    </Style>
-                    <DataTemplate x:Key="ResultTemplate">
-                        <Border>
-                            <StackPanel Orientation="Horizontal" Margin="5">
-                                <Image Source="{Binding Icon}" Width="24" Height="24" Margin="0,0,10,0" VerticalAlignment="Center"/>
-                                <StackPanel Orientation="Vertical" Margin="5">
-                                    <TextBlock Text="{Binding DisplayName}" 
-                               FontSize="16" 
-                               Foreground="White"
-                               VerticalAlignment="Center"
-                               TextTrimming="CharacterEllipsis"/>
-                                    <TextBlock Text="{Binding FullPath}" 
-                               FontSize="12" 
-                               Foreground="Gray" 
-                               TextTrimming="CharacterEllipsis"
-                               TextWrapping="NoWrap"
-                               MaxWidth="500"
-                               Margin="0,2,0,0"/>
-                                </StackPanel>
-                            </StackPanel>
-                            <Border.ContextMenu>
-                                <ContextMenu>
-                                    <MenuItem Header="Ouvrir" Click="OpenFile_Click"/>
-                                    <MenuItem Header="Ouvrir l'emplacement" Click="OpenLocation_Click"/>
-                                    <MenuItem Header="Copier le chemin" Click="CopyPath_Click"/>
-                                    <Separator />
-                                    <MenuItem Header="Supprimer" Click="DeleteFile_Click"/>
-                                    <MenuItem Header="Renommer" Click="RenameFile_Click"/>
-                                    <Separator />
-                                    <MenuItem Header="Propriétés" Click="ShowProperties_Click"/>
-                                </ContextMenu>
-                            </Border.ContextMenu>
-                        </Border>
-                    </DataTemplate>
-                </ListBox.Resources>
-                <ListBox.ItemTemplate>
-                    <StaticResource ResourceKey="ResultTemplate"/>
-                </ListBox.ItemTemplate>
-            </ListBox>
-        </Grid>
+           <!-- Liste des résultats -->
+           <ListBox x:Name="ResultsList"
+                    Width="600"
+                    Margin="100,100,100,20"
+                    HorizontalAlignment="Center"
+                    VerticalAlignment="Top"
+                    Background="#CC333333"
+                    Foreground="White"
+                    BorderBrush="White"
+                    BorderThickness="0"
+                    Visibility="Collapsed"
+                    FontSize="16"
+                    ScrollViewer.VerticalScrollBarVisibility="Hidden"
+                    ScrollViewer.HorizontalScrollBarVisibility="Disabled"
+                    KeyDown="ResultsList_KeyDown">
+               <ListBox.Resources>
+                   <Style TargetType="{x:Type ScrollBar}">
+                       <Setter Property="Width" Value="8"/>
+                       <Setter Property="Background" Value="Transparent"/>
+                       <Setter Property="Foreground" Value="#66FFFFFF"/>
+                   </Style>
+                   <DataTemplate x:Key="ResultTemplate">
+                       <Border>
+                           <StackPanel Orientation="Horizontal" Margin="5">
+                               <Image Source="{Binding Icon}" Width="24" Height="24" Margin="0,0,10,0" VerticalAlignment="Center"/>
+                               <StackPanel Orientation="Vertical" Margin="5">
+                                   <TextBlock Text="{Binding DisplayName}" 
+                              FontSize="16" 
+                              Foreground="White"
+                              VerticalAlignment="Center"
+                              TextTrimming="CharacterEllipsis"/>
+                                   <TextBlock Text="{Binding FullPath}" 
+                              FontSize="12" 
+                              Foreground="Gray" 
+                              TextTrimming="CharacterEllipsis"
+                              TextWrapping="NoWrap"
+                              MaxWidth="500"
+                              Margin="0,2,0,0"/>
+                               </StackPanel>
+                           </StackPanel>
+                           <Border.ContextMenu>
+                               <ContextMenu>
+                                   <MenuItem Header="Ouvrir" Click="OpenFile_Click"/>
+                                   <MenuItem Header="Ouvrir l'emplacement" Click="OpenLocation_Click"/>
+                                   <MenuItem Header="Copier le chemin" Click="CopyPath_Click"/>
+                                   <Separator />
+                                   <MenuItem Header="Supprimer" Click="DeleteFile_Click"/>
+                                   <MenuItem Header="Renommer" Click="RenameFile_Click"/>
+                                   <Separator />
+                                   <MenuItem Header="Propriétés" Click="ShowProperties_Click"/>
+                               </ContextMenu>
+                           </Border.ContextMenu>
+                       </Border>
+                   </DataTemplate>
+               </ListBox.Resources>
+               <ListBox.ItemTemplate>
+                   <StaticResource ResourceKey="ResultTemplate"/>
+               </ListBox.ItemTemplate>
+           </ListBox>
+       </Grid>
         <TextBlock x:Name="LoadingIndicator"
-           Text="Indexation en cours..."
-           Foreground="White"
-           FontSize="16"
-           HorizontalAlignment="Center"
-           VerticalAlignment="Top"
-           Margin="0,20,0,0"
-           Visibility="Collapsed"
-           />
+          Text="Indexation en cours..."
+          Foreground="White"
+          FontSize="16"
+          HorizontalAlignment="Center"
+          VerticalAlignment="Top"
+          Margin="0,20,0,0"
+          Visibility="Collapsed"
+          />
     </Grid>
 </Window>

--- a/WannaTool/MainWindow.xaml
+++ b/WannaTool/MainWindow.xaml
@@ -1,0 +1,144 @@
+﻿<Window x:Class="WannaTool.MainWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="WannaTool"
+        WindowStartupLocation="CenterScreen"
+        WindowStyle="None"
+        AllowsTransparency="True"
+        Background="Transparent"
+        ShowInTaskbar="False"
+        Topmost="True"
+        Width="800" Height="300">
+
+    <Grid Background="Transparent">
+        <!-- Fond semi-transparent -->
+        <Grid Background="#80000000">
+
+            <!-- Barre de recherche -->
+            <Border 
+                Background="#CC333333" 
+                CornerRadius="15" 
+                HorizontalAlignment="Center" 
+                VerticalAlignment="Top"
+                Width="600" Height="50"
+                Margin="0,30,0,0"
+                Padding="10">
+
+                <Border.Effect>
+                    <DropShadowEffect 
+                        Color="Black" 
+                        BlurRadius="20" 
+                        Opacity="0.5" 
+                        ShadowDepth="5" />
+                </Border.Effect>
+
+                <TextBox Name="SearchBox"
+                         FontSize="18"
+                         Background="Transparent"
+                         BorderThickness="0"
+                         Foreground="White"
+                         VerticalContentAlignment="Center"
+                         HorizontalContentAlignment="Left"
+                         Margin="5,0"
+                         TextChanged="SearchBox_TextChanged">
+                    <TextBox.Style>
+                        <Style TargetType="TextBox">
+                            <Setter Property="Template">
+                                <Setter.Value>
+                                    <ControlTemplate TargetType="TextBox">
+                                        <Grid>
+                                            <TextBox Text="{Binding Text, RelativeSource={RelativeSource TemplatedParent}, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                                                     Background="Transparent"
+                                                     BorderThickness="0"
+                                                     Foreground="White"
+                                                     CaretBrush="White"
+                                                     VerticalContentAlignment="Center"
+                                                     HorizontalContentAlignment="Left" />
+                                            <TextBlock Text="Rechercher..."
+                                                       Foreground="Gray"
+                                                       VerticalAlignment="Center"
+                                                       HorizontalAlignment="Left"
+                                                       Margin="5,0"
+                                                       IsHitTestVisible="False"
+                                                       Visibility="{Binding Text, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource StringNotNullOrEmptyToVisibilityConverter}}" />
+                                        </Grid>
+                                    </ControlTemplate>
+                                </Setter.Value>
+                            </Setter>
+                        </Style>
+                    </TextBox.Style>
+                </TextBox>
+
+            </Border>
+
+            <!-- Liste des résultats -->
+            <ListBox x:Name="ResultsList"
+         Width="600"
+         Margin="100,100,100,20"
+         HorizontalAlignment="Center"
+         VerticalAlignment="Top"
+         Background="#CC333333"
+         Foreground="White"
+         BorderBrush="White"
+         BorderThickness="0"
+         Visibility="Collapsed"
+         MouseDoubleClick="ResultsList_MouseDoubleClick"
+         FontSize="16"
+         ScrollViewer.VerticalScrollBarVisibility="Auto"
+         ScrollViewer.HorizontalScrollBarVisibility="Disabled">
+                <ListBox.Resources>
+                    <Style TargetType="{x:Type ScrollBar}">
+                        <Setter Property="Width" Value="8"/>
+                        <Setter Property="Background" Value="Transparent"/>
+                        <Setter Property="Foreground" Value="#66FFFFFF"/>
+                    </Style>
+                    <DataTemplate x:Key="ResultTemplate">
+                        <Border>
+                            <StackPanel Orientation="Horizontal" Margin="5">
+                                <Image Source="{Binding Icon}" Width="24" Height="24" Margin="0,0,10,0" VerticalAlignment="Center"/>
+                                <StackPanel Orientation="Vertical" Margin="5">
+                                    <TextBlock Text="{Binding DisplayName}" 
+                               FontSize="16" 
+                               Foreground="White"
+                               VerticalAlignment="Center"
+                               TextTrimming="CharacterEllipsis"/>
+                                    <TextBlock Text="{Binding FullPath}" 
+                               FontSize="12" 
+                               Foreground="Gray" 
+                               TextTrimming="CharacterEllipsis"
+                               TextWrapping="NoWrap"
+                               MaxWidth="500"
+                               Margin="0,2,0,0"/>
+                                </StackPanel>
+                            </StackPanel>
+                            <Border.ContextMenu>
+                                <ContextMenu>
+                                    <MenuItem Header="Ouvrir" Click="OpenFile_Click"/>
+                                    <MenuItem Header="Ouvrir l'emplacement" Click="OpenLocation_Click"/>
+                                    <MenuItem Header="Copier le chemin" Click="CopyPath_Click"/>
+                                    <Separator />
+                                    <MenuItem Header="Supprimer" Click="DeleteFile_Click"/>
+                                    <MenuItem Header="Renommer" Click="RenameFile_Click"/>
+                                    <Separator />
+                                    <MenuItem Header="Propriétés" Click="ShowProperties_Click"/>
+                                </ContextMenu>
+                            </Border.ContextMenu>
+                        </Border>
+                    </DataTemplate>
+                </ListBox.Resources>
+                <ListBox.ItemTemplate>
+                    <StaticResource ResourceKey="ResultTemplate"/>
+                </ListBox.ItemTemplate>
+            </ListBox>
+        </Grid>
+        <TextBlock x:Name="LoadingIndicator"
+           Text="Indexation en cours..."
+           Foreground="White"
+           FontSize="16"
+           HorizontalAlignment="Center"
+           VerticalAlignment="Top"
+           Margin="0,20,0,0"
+           Visibility="Collapsed"
+           />
+    </Grid>
+</Window>

--- a/WannaTool/MainWindow.xaml.cs
+++ b/WannaTool/MainWindow.xaml.cs
@@ -1,33 +1,11 @@
-﻿using System;
-using System.Globalization;
+using System;
 using System.Runtime.InteropServices;
 using System.Windows;
-using System.Windows.Data;
-using System.Windows.Interop;
-using System.Windows.Threading;
-using MessageBox = System.Windows.MessageBox;
-using System.Diagnostics;
-using System.Windows.Controls;
 using System.Windows.Input;
-using System.Windows.Media;
-using System.Windows.Media.Imaging;
-using Application = System.Windows.Application;
-using Clipboard = System.Windows.Clipboard;
-using System.IO;
-using System.ComponentModel;
-using System.Net.Http.Headers;
-using System.Net.Http;
-using System.Text.Json;
-using System.Text;
-using KeyEventArgs = System.Windows.Input.KeyEventArgs;
-using System.Windows.Media.Animation;
-using Color = System.Windows.Media.Color;
-using Microsoft.Toolkit.Uwp.Notifications;
-using NHotkey.Wpf;
+using System.Windows.Interop;
 using NHotkey;
-using DotNetEnv;
-
-
+using NHotkey.Wpf;
+using MessageBox = System.Windows.MessageBox;
 
 namespace WannaTool
 {
@@ -35,25 +13,24 @@ namespace WannaTool
     {
         private const int WM_HOTKEY = 0x0312;
         private const int MOD_ALT = 0x0001;
-        private const int VK_F9 = 0x78;
         private const int VK_SPACE = 0x20;
+        private const int HOTKEY_ID = 9000;
+
+        private MainViewModel _viewModel;
 
         public MainWindow()
         {
             InitializeComponent();
+            
+            _viewModel = new MainViewModel();
+            DataContext = _viewModel;
 
-            this.Width = SystemParameters.WorkArea.Width;
-            this.Height = SystemParameters.WorkArea.Height;
-            this.Left = SystemParameters.WorkArea.Left;
-            this.Top = SystemParameters.WorkArea.Top;
+            this.Loaded += OnLoaded;
+            this.Deactivated += (s, e) => this.Hide();
+        }
 
-            SearchBox.PreviewKeyDown += SearchBox_KeyDown;
-
-            ApplyBlurEffect();
-            SearchBox.Focus();
-
-            ShowLoadingIndicatorWhileIndexing();
-
+        private void OnLoaded(object sender, RoutedEventArgs e)
+        {
             try
             {
                 HotkeyManager.Current.AddOrReplace("CapturePrimary", Key.F5, ModifierKeys.Control | ModifierKeys.Shift, OnCapturePrimary);
@@ -61,191 +38,60 @@ namespace WannaTool
             }
             catch (Exception ex)
             {
-                MessageBox.Show($"Erreur lors de l'enregistrement des raccourcis : {ex.Message}");
+                MessageBox.Show($"Error registering hotkeys: {ex.Message}");
             }
+
+            var helper = new WindowInteropHelper(this);
+            var source = HwndSource.FromHwnd(helper.Handle);
+            source?.AddHook(WndProc);
+            
+            RegisterHotKey(helper.Handle, HOTKEY_ID, MOD_ALT, VK_SPACE);
+
+            this.Hide();
         }
 
-        private void OnCapturePrimary(object sender, HotkeyEventArgs e)
+        private void OnCapturePrimary(object? sender, HotkeyEventArgs e)
         {
             ScreenCaptureManager.CapturePrimary();
             e.Handled = true;
         }
 
-        private void OnCaptureAll(object sender, HotkeyEventArgs e)
+        private void OnCaptureAll(object? sender, HotkeyEventArgs e)
         {
             ScreenCaptureManager.CaptureAll();
             e.Handled = true;
         }
 
-        private async void ShowLoadingIndicatorWhileIndexing()
-        {
-            LoadingIndicator.Visibility = Visibility.Visible;
-
-            await Task.Run(() => Indexer.InitializeAsync());
-
-            Application.Current.Dispatcher.Invoke(() =>
-            {
-                LoadingIndicator.Visibility = Visibility.Collapsed;
-            });
-        }
-
-        private void ShowToast(string title, string message)
-        {
-            new ToastContentBuilder()
-                .AddText(title)
-                .AddText(message)
-                .Show();
-        }
-
-        [StructLayout(LayoutKind.Sequential)]
-        private struct SHFILEINFO
-        {
-            public IntPtr hIcon;
-            public IntPtr iIcon;
-            public uint dwAttributes;
-            [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 260)]
-            public string szDisplayName;
-            [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 80)]
-            public string szTypeName;
-        };
-
-        [DllImport("shell32.dll")]
-        private static extern IntPtr SHGetFileInfo(string pszPath, uint dwFileAttributes,
-            ref SHFILEINFO psfi, uint cbFileInfo, uint uFlags);
-
-        [DllImport("user32.dll", SetLastError = true)]
-        [return: MarshalAs(UnmanagedType.Bool)]
-        private static extern bool DestroyIcon(IntPtr hIcon);
-
-        protected override void OnSourceInitialized(EventArgs e)
-        {
-            base.OnSourceInitialized(e);
-
-            var helper = new WindowInteropHelper(this);
-            var source = HwndSource.FromHwnd(helper.Handle);
-
-            if (source != null)
-            {
-                source.AddHook(WndProc);
-
-                bool registered = RegisterHotKey(helper.Handle, 9000, MOD_ALT, VK_SPACE);
-                if (!registered)
-                {
-                    MessageBox.Show("Failed to register hotkey.", "Error", MessageBoxButton.OK, MessageBoxImage.Error);
-                }
-
-                // Ne cacher la fenêtre qu'après le hook ET le register
-                Dispatcher.BeginInvoke(new Action(() => this.Hide()), DispatcherPriority.ApplicationIdle);
-            }
-            else
-            {
-                MessageBox.Show("Impossible d'obtenir le handle de la fenêtre.", "Erreur", MessageBoxButton.OK, MessageBoxImage.Error);
-            }
-        }
-
-        private async void SearchBox_KeyDown(object sender, KeyEventArgs e)
-        {
-            if (e.Key == Key.Enter && ResultsList.HasItems)
-            {
-                var first = ResultsList.Items[0] as SearchResult;
-                if (first != null)
-                {
-                    await ExecuteSearchResult(first);
-                    ResultsList.SelectedItem = null;
-                }
-                e.Handled = true;
-                return;
-            }
-
-            if ((e.Key == Key.Up || e.Key == Key.Down) && ResultsList.HasItems)
-            {
-                // choisir l'index
-                int idx = e.Key == Key.Down ? 0 : ResultsList.Items.Count - 1;
-                ResultsList.SelectedIndex = idx;
-
-                // récupérer le conteneur et y mettre le focus clavier
-                var container = ResultsList.ItemContainerGenerator
-                                   .ContainerFromIndex(idx) as ListBoxItem;
-                if (container != null)
-                {
-                    container.IsSelected = true;
-                    container.Focus();
-                    Keyboard.Focus(container);
-                }
-
-                e.Handled = true;
-                return;
-            }
-        }
-
-        protected override void OnPreviewKeyDown(System.Windows.Input.KeyEventArgs e)
-        {
-            base.OnPreviewKeyDown(e);
-
-            if (e.Key == System.Windows.Input.Key.Escape)
-            {
-                this.Hide();
-            }
-        }
-
-        private async void ResultsList_KeyDown(object sender, KeyEventArgs e)
-        {
-            if (e.Key == Key.Enter && ResultsList.SelectedItem is SearchResult selected)
-            {
-                await ExecuteSearchResult(selected);
-                ResultsList.SelectedItem = null;
-                this.Hide();
-            }
-        }
-
-        private DateTime _lastHotkeyPress = DateTime.MinValue; // Stocke le dernier moment où le hotkey a été pressé
-        private readonly TimeSpan _hotkeyCooldown = TimeSpan.FromMilliseconds(500); // Cooldown de 500ms
-
         private IntPtr WndProc(IntPtr hwnd, int msg, IntPtr wParam, IntPtr lParam, ref bool handled)
         {
-            if (msg == WM_HOTKEY)
+            if (msg == WM_HOTKEY && wParam.ToInt32() == HOTKEY_ID)
             {
-                if (DateTime.Now - _lastHotkeyPress < _hotkeyCooldown)
-                {
-                    handled = true;
-                    return IntPtr.Zero;
-                }
-
-                _lastHotkeyPress = DateTime.Now;
-
-
-                if (this.Visibility == Visibility.Visible)
-                {
-                    var fadeOut = new System.Windows.Media.Animation.DoubleAnimation(1, 0, TimeSpan.FromMilliseconds(200));
-                    fadeOut.Completed += (s, e) =>
-                    {
-                        this.Hide();
-                        ResultsList.ItemsSource = null;
-                        ResultsList.Visibility = Visibility.Collapsed;
-                        SearchBox.Text = string.Empty;
-                    };
-                    this.BeginAnimation(Window.OpacityProperty, fadeOut);
-                }
-                else
-                {
-                    this.Opacity = 0;
-                    this.Show();
-                    this.WindowState = WindowState.Normal;
-                    this.Activate();
-                    this.Topmost = true;
-                    var fadeIn = new System.Windows.Media.Animation.DoubleAnimation(0, 1, TimeSpan.FromMilliseconds(200));
-                    this.BeginAnimation(Window.OpacityProperty, fadeIn);
-                }
-
+                ToggleVisibility();
                 handled = true;
             }
             return IntPtr.Zero;
         }
 
+        private void ToggleVisibility()
+        {
+            if (this.Visibility == Visibility.Visible)
+            {
+                this.Hide();
+            }
+            else
+            {
+                this.Show();
+                this.Activate();
+                this.Topmost = true;
+                SearchBox.Focus();
+                SearchBox.SelectAll();
+            }
+        }
+
         protected override void OnClosed(EventArgs e)
         {
             var helper = new WindowInteropHelper(this);
-            UnregisterHotKey(helper.Handle, 9000);
+            UnregisterHotKey(helper.Handle, HOTKEY_ID);
             base.OnClosed(e);
         }
 
@@ -254,378 +100,5 @@ namespace WannaTool
 
         [DllImport("user32.dll")]
         private static extern bool UnregisterHotKey(IntPtr hWnd, int id);
-
-        private async void SearchBox_TextChanged(object sender, TextChangedEventArgs e)
-        {
-            if (ResultsList == null) return;
-
-            var query = SearchBox.Text.Trim();
-            if (query.Length < 2)
-            {
-                ResultsList.Visibility = Visibility.Collapsed;
-                ResultsList.ItemsSource = null;
-                GC.Collect();
-                return;
-            }
-
-
-            var colon = query.IndexOf(':');
-            if (colon > 0 && colon < query.Length - 1)
-            {
-                var prefix = query[..colon].ToLowerInvariant();
-                var term = query[(colon + 1)..].Trim();
-                if (!string.IsNullOrEmpty(term))
-                {
-                    string[] exts = prefix switch
-                    {
-                        "pdf" => new[] { ".pdf" },
-                        "img" => new[] { ".png", ".jpg", ".jpeg", ".gif", ".bmp" },
-                        "code" => new[] { ".cs", ".js", ".ts", ".html", ".css", ".json", ".xml", ".cpp", ".java" },
-                        _ => null
-                    };
-                    if (exts != null)
-                    {
-                        var filtered = Indexer.Search(term, exts);
-                        if (filtered.Any())
-                        {
-                            ResultsList.ItemsSource = filtered;
-                            ResultsList.Visibility = Visibility.Visible;
-                            return;
-                        }
-                    }
-                }
-            }
-
-            var redirect = SearchRedirects.TryParseRedirect(query);
-            if (redirect != null)
-            {
-                ResultsList.ItemsSource = new List<SearchResult> { redirect };
-                ResultsList.Visibility = Visibility.Visible;
-                return;
-            }
-
-            var results = Indexer.Search(query);
-
-            if (!results.Any())
-            {
-
-
-                results.Add(new SearchResult
-                {
-                    DisplayName = $"Search Google for \"{query}\"",
-                    FullPath = $"https://www.google.com/search?q={Uri.EscapeDataString(query)}"
-                });
-            }
-
-            ResultsList.ItemsSource = results;
-            ResultsList.Visibility = Visibility.Visible;
-        }
-
-        public class SearchResult : INotifyPropertyChanged
-        {
-            public string DisplayName { get; set; }
-            public string FullPath { get; set; }
-            public bool IsFolder { get; set; }
-
-            private ImageSource? _icon;
-            public ImageSource? Icon
-            {
-                get
-                {
-                    if (_icon == null)
-                        _icon = IconLoader.GetIcon(FullPath, IsFolder);
-                    return _icon;
-                }
-            }
-
-            public override string ToString()
-            {
-                return DisplayName;
-            }
-
-            private bool _isRenaming;
-            public bool IsRenaming
-            {
-                get => _isRenaming;
-                set { _isRenaming = value; OnPropertyChanged(nameof(IsRenaming)); }
-            }
-
-            public event PropertyChangedEventHandler PropertyChanged;
-            protected void OnPropertyChanged(string name) =>
-                PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
-        }
-
-        private static readonly HttpClient _httpClient = new();
-
-        private void SafeSetClipboardText(string text)
-        {
-            int retries = 10;
-            int delay = 50;
-
-            while (retries > 0)
-            {
-                try
-                {
-                    Clipboard.SetText(text);
-                    return;
-                }
-                catch (System.Runtime.InteropServices.COMException)
-                {
-                    retries--;
-                    Thread.Sleep(delay);
-                }
-            }
-
-            MessageBox.Show("Impossible d'accéder au presse-papier. Réessaie ou ferme les applications qui pourraient le bloquer.", "Erreur", MessageBoxButton.OK, MessageBoxImage.Warning);
-        }
-
-        [DllImport("user32.dll")]
-        internal static extern int SetWindowCompositionAttribute(IntPtr hwnd, ref WindowCompositionAttributeData data);
-
-        private void ApplyBlurEffect()
-        {
-            var windowHelper = new WindowInteropHelper(this);
-            var accent = new AccentPolicy
-            {
-                AccentState = AccentState.ACCENT_ENABLE_BLURBEHIND
-            };
-
-            var accentStructSize = Marshal.SizeOf(accent);
-            var accentPtr = Marshal.AllocHGlobal(accentStructSize);
-            Marshal.StructureToPtr(accent, accentPtr, false);
-
-            var data = new WindowCompositionAttributeData
-            {
-                Attribute = WindowCompositionAttribute.WCA_ACCENT_POLICY,
-                SizeOfData = accentStructSize,
-                Data = accentPtr
-            };
-
-            SetWindowCompositionAttribute(windowHelper.Handle, ref data);
-            Marshal.FreeHGlobal(accentPtr);
-        }
-
-        [StructLayout(LayoutKind.Sequential)]
-        internal struct AccentPolicy
-        {
-            public AccentState AccentState;
-            public int AccentFlags;
-            public int GradientColor;
-            public int AnimationId;
-        }
-
-        internal enum AccentState
-        {
-            ACCENT_DISABLED = 0,
-            ACCENT_ENABLE_GRADIENT = 1,
-            ACCENT_ENABLE_TRANSPARENTGRADIENT = 2,
-            ACCENT_ENABLE_BLURBEHIND = 3,
-            ACCENT_ENABLE_ACRYLICBLURBEHIND = 4,
-            ACCENT_ENABLE_HOSTBACKDROP = 5
-        }
-
-        [StructLayout(LayoutKind.Sequential)]
-        internal struct WindowCompositionAttributeData
-        {
-            public WindowCompositionAttribute Attribute;
-            public IntPtr Data;
-            public int SizeOfData;
-        }
-
-        internal enum WindowCompositionAttribute
-        {
-            WCA_ACCENT_POLICY = 19
-        }
-
-        private void OpenFile_Click(object sender, RoutedEventArgs e)
-        {
-            if (ResultsList.SelectedItem is SearchResult selected)
-            {
-                Process.Start(new ProcessStartInfo(selected.FullPath) { UseShellExecute = true });
-                this.Hide();
-            }
-        }
-        private void OpenLocation_Click(object sender, RoutedEventArgs e)
-        {
-            if (ResultsList.SelectedItem is SearchResult selected)
-            {
-                Process.Start(new ProcessStartInfo("explorer.exe", $"/select,\"{selected.FullPath}\""));
-                this.Hide();
-            }
-        }
-        private void CopyPath_Click(object sender, RoutedEventArgs e)
-        {
-            if (ResultsList.SelectedItem is SearchResult selected)
-            {
-                Clipboard.SetText(selected.FullPath);
-            }
-        }
-        private void DeleteFile_Click(object sender, RoutedEventArgs e)
-        {
-            if (ResultsList.SelectedItem is SearchResult selected)
-            {
-                this.Hide();
-                if (MessageBox.Show($"Êtes-vous sûr de vouloir supprimer {selected.DisplayName} ?", "Confirmation", MessageBoxButton.YesNo, MessageBoxImage.Warning) == MessageBoxResult.Yes)
-                {
-                    try
-                    {
-                        File.Delete(selected.FullPath);
-                        MessageBox.Show($"{selected.DisplayName} a été supprimé avec succès.", "Succès", MessageBoxButton.OK, MessageBoxImage.Information);
-                    }
-                    catch (Exception ex)
-                    {
-                        MessageBox.Show($"Erreur lors de la suppression : {ex.Message}", "Erreur", MessageBoxButton.OK, MessageBoxImage.Error);
-                    }
-                }
-            }
-        }
-        private void RenameFile_Click(object sender, RoutedEventArgs e)
-        {
-            this.Hide();
-            if (ResultsList.SelectedItem is not SearchResult selected) return;
-
-            string currentName = Path.GetFileName(selected.FullPath);
-            string input = Microsoft.VisualBasic.Interaction.InputBox("Entrez le nouveau nom :", "Renommer", currentName);
-
-            if (string.IsNullOrWhiteSpace(input)) return;
-
-            string newPath = Path.Combine(Path.GetDirectoryName(selected.FullPath), input);
-
-            try
-            {
-                if (File.Exists(newPath) || Directory.Exists(newPath))
-                {
-                    MessageBox.Show("Un fichier ou dossier portant ce nom existe déjà.", "Conflit", MessageBoxButton.OK, MessageBoxImage.Warning);
-                    return;
-                }
-
-                File.Move(selected.FullPath, newPath);
-                selected.FullPath = newPath;
-                selected.DisplayName = input;
-
-                ResultsList.Items.Refresh();
-
-                Utils.ShowToast("Fichier renommé", $"{currentName} renommé en {input}");
-            }
-            catch (Exception ex)
-            {
-                MessageBox.Show($"Erreur : {ex.Message}", "Renommage", MessageBoxButton.OK, MessageBoxImage.Error);
-                Utils.ShowToast("Erreur renommage", ex.Message, true);
-            }
-        }
-
-        [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Auto)]
-        public struct SHELLEXECUTEINFO
-        {
-            public int cbSize;
-            public uint fMask;
-            public IntPtr hwnd;
-            [MarshalAs(UnmanagedType.LPTStr)]
-            public string lpVerb;
-            [MarshalAs(UnmanagedType.LPTStr)]
-            public string lpFile;
-            [MarshalAs(UnmanagedType.LPTStr)]
-            public string lpParameters;
-            [MarshalAs(UnmanagedType.LPTStr)]
-            public string lpDirectory;
-            public int nShow;
-            public IntPtr hInstApp;
-            public IntPtr lpIDList;
-            [MarshalAs(UnmanagedType.LPTStr)]
-            public string lpClass;
-            public IntPtr hkeyClass;
-            public uint dwHotKey;
-            public IntPtr hIcon;
-            public IntPtr hProcess;
-        }
-
-        [DllImport("shell32.dll", CharSet = CharSet.Auto)]
-        static extern bool ShellExecuteEx(ref SHELLEXECUTEINFO lpExecInfo);
-
-        private void ShowProperties_Click(object sender, RoutedEventArgs e)
-        {
-            if (ResultsList.SelectedItem is SearchResult selected)
-            {
-                try
-                {
-                    SHELLEXECUTEINFO info = new SHELLEXECUTEINFO();
-                    info.cbSize = Marshal.SizeOf(info);
-                    info.lpFile = selected.FullPath;
-                    info.lpVerb = "properties";
-                    info.nShow = 5; // SW_SHOW
-                    info.fMask = 0x0000000C; // SEE_MASK_INVOKEIDLIST | SEE_MASK_FLAG_NO_UI
-
-                    ShellExecuteEx(ref info);
-                    this.Hide();
-
-                }
-                catch (Exception ex)
-                {
-                    MessageBox.Show($"Erreur lors de l'ouverture des propriétés : {ex.Message}", "Erreur", MessageBoxButton.OK, MessageBoxImage.Error);
-                    Utils.ShowToast("Erreur", $"Erreur propriétés : {ex.Message}", true);
-                }
-            }
-        }
-
-        private async Task ExecuteSearchResult(SearchResult selected)
-        {
-            if (selected.FullPath == "!help")
-            {
-                string helpPath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "Docs", "index.html");
-                if (File.Exists(helpPath))
-                {
-                    Process.Start(new ProcessStartInfo(helpPath) { UseShellExecute = true });
-                    this.Hide();
-                }
-                else
-                {
-                    MessageBox.Show("Le fichier d'aide est introuvable.");
-                }
-                return;
-            }
-
-            if (selected.FullPath.StartsWith("http"))
-            {
-                Process.Start(new ProcessStartInfo(selected.FullPath) { UseShellExecute = true });
-            }
-            else
-            {
-                Process.Start(new ProcessStartInfo(selected.FullPath) { UseShellExecute = true });
-            }
-
-            ResultsList.SelectedItem = null;
-            this.Hide();
-        }
-
     }
-
-    public class StringNullOrEmptyToVisibilityConverter : IValueConverter
-        {
-            public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
-            {
-                if (value is string str && !string.IsNullOrEmpty(str))
-                {
-                    return Visibility.Visible;
-                }
-                return Visibility.Collapsed;
-            }
-
-            public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
-            {
-                throw new NotImplementedException();
-            }
-        }
-
-        public class StringNotNullOrEmptyToVisibilityConverter : IValueConverter
-        {
-            public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
-            {
-                return string.IsNullOrEmpty(value as string) ? Visibility.Visible : Visibility.Collapsed;
-            }
-
-            public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
-            {
-                throw new NotImplementedException();
-            }
-        }
 }

--- a/WannaTool/MainWindow.xaml.cs
+++ b/WannaTool/MainWindow.xaml.cs
@@ -1,0 +1,450 @@
+﻿using System;
+using System.Globalization;
+using System.Runtime.InteropServices;
+using System.Windows;
+using System.Windows.Data;
+using System.Windows.Interop;
+using System.Windows.Threading;
+using MessageBox = System.Windows.MessageBox;
+using System.Diagnostics;
+using System.Windows.Controls;
+using System.Windows.Input;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+using Application = System.Windows.Application;
+using Clipboard = System.Windows.Clipboard;
+using System.IO;
+
+namespace WannaTool
+{
+    public partial class MainWindow : Window
+    {
+        private const int WM_HOTKEY = 0x0312;
+        private const int MOD_ALT = 0x0001;
+        private const int VK_F9 = 0x78;
+        private const int VK_SPACE = 0x20;
+
+        public MainWindow()
+        {
+            InitializeComponent();
+            Task.Run(() => Indexer.InitializeAsync());
+
+            this.Width = SystemParameters.WorkArea.Width;
+            this.Height = SystemParameters.WorkArea.Height;
+            this.Left = SystemParameters.WorkArea.Left;
+            this.Top = SystemParameters.WorkArea.Top;
+
+            ApplyBlurEffect();
+            SearchBox.Focus();
+
+            ShowLoadingIndicatorWhileIndexing();
+        }
+
+        private async void ShowLoadingIndicatorWhileIndexing()
+        {
+            LoadingIndicator.Visibility = Visibility.Visible;
+
+            await Task.Run(() => Indexer.InitializeAsync());
+
+            Application.Current.Dispatcher.Invoke(() =>
+            {
+                LoadingIndicator.Visibility = Visibility.Collapsed;
+            });
+        }
+
+        private async void LoadIconForResult(SearchResult result)
+        {
+            if (result.Icon != null) return; // Déjà chargé
+
+            await Task.Run(() =>
+            {
+                try
+                {
+                    var shinfo = new SHFILEINFO();
+                    IntPtr hImg = SHGetFileInfo(result.FullPath, 0, ref shinfo, (uint)Marshal.SizeOf(shinfo), 0x000000100 | 0x000000001);
+
+                    if (hImg != IntPtr.Zero)
+                    {
+                        var icon = Imaging.CreateBitmapSourceFromHIcon(
+                            shinfo.hIcon,
+                            Int32Rect.Empty,
+                            BitmapSizeOptions.FromEmptyOptions());
+
+                        icon.Freeze(); // Important pour éviter des erreurs threading
+
+                        Application.Current.Dispatcher.Invoke(() =>
+                        {
+                            result.Icon = icon;
+                        });
+                    }
+                }
+                catch
+                {
+                    // Ignore erreurs fichiers non trouvés
+                }
+            });
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        private struct SHFILEINFO
+        {
+            public IntPtr hIcon;
+            public IntPtr iIcon;
+            public uint dwAttributes;
+            [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 260)]
+            public string szDisplayName;
+            [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 80)]
+            public string szTypeName;
+        };
+
+        [DllImport("shell32.dll")]
+        private static extern IntPtr SHGetFileInfo(string pszPath, uint dwFileAttributes,
+            ref SHFILEINFO psfi, uint cbFileInfo, uint uFlags);
+
+        [DllImport("user32.dll", SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        private static extern bool DestroyIcon(IntPtr hIcon);
+
+        protected override void OnSourceInitialized(EventArgs e)
+        {
+            base.OnSourceInitialized(e);
+
+            var helper = new WindowInteropHelper(this);
+            var source = HwndSource.FromHwnd(helper.Handle);
+
+            if (source != null)
+            {
+                source.AddHook(WndProc);
+
+                bool registered = RegisterHotKey(helper.Handle, 9000, MOD_ALT, VK_SPACE);
+                if (!registered)
+                {
+                    MessageBox.Show("Failed to register hotkey.", "Error", MessageBoxButton.OK, MessageBoxImage.Error);
+                }
+
+                // Ne cacher la fenêtre qu'après le hook ET le register
+                Dispatcher.BeginInvoke(new Action(() => this.Hide()), DispatcherPriority.ApplicationIdle);
+            }
+            else
+            {
+                MessageBox.Show("Impossible d'obtenir le handle de la fenêtre.", "Erreur", MessageBoxButton.OK, MessageBoxImage.Error);
+            }
+        }
+
+        protected override void OnPreviewKeyDown(System.Windows.Input.KeyEventArgs e)
+        {
+            base.OnPreviewKeyDown(e);
+
+            if (e.Key == System.Windows.Input.Key.Escape)
+            {
+                this.Hide();
+            }
+        }
+
+        private DateTime _lastHotkeyPress = DateTime.MinValue; // Stocke le dernier moment où le hotkey a été pressé
+        private readonly TimeSpan _hotkeyCooldown = TimeSpan.FromMilliseconds(500); // Cooldown de 500ms
+
+        private IntPtr WndProc(IntPtr hwnd, int msg, IntPtr wParam, IntPtr lParam, ref bool handled)
+        {
+            if (msg == WM_HOTKEY)
+            {
+                if (DateTime.Now - _lastHotkeyPress < _hotkeyCooldown)
+                {
+                    handled = true; // Ignorez l'événement si le cooldown n'est pas terminé
+                    return IntPtr.Zero;
+                }
+
+                _lastHotkeyPress = DateTime.Now;
+
+
+                if (this.Visibility == Visibility.Visible)
+                {
+                    var fadeOut = new System.Windows.Media.Animation.DoubleAnimation(1, 0, TimeSpan.FromMilliseconds(200));
+                    fadeOut.Completed += (s, e) =>
+                    {
+                        this.Hide();
+                        ResultsList.ItemsSource = null;
+                        ResultsList.Visibility = Visibility.Collapsed;
+                        SearchBox.Text = string.Empty;
+
+                        Indexer.ClearIndex();
+
+                        GC.Collect();
+                        GC.WaitForPendingFinalizers();
+                        GC.Collect();
+                    };
+                    this.BeginAnimation(Window.OpacityProperty, fadeOut);
+                }
+                else
+                {
+                    this.Opacity = 0;
+                    this.Show();
+                    this.WindowState = WindowState.Normal;
+                    this.Activate();
+                    this.Topmost = true;
+                    var fadeIn = new System.Windows.Media.Animation.DoubleAnimation(0, 1, TimeSpan.FromMilliseconds(200));
+                    this.BeginAnimation(Window.OpacityProperty, fadeIn);
+                }
+
+                handled = true;
+            }
+            return IntPtr.Zero;
+        }
+
+        protected override void OnClosed(EventArgs e)
+        {
+            var helper = new WindowInteropHelper(this);
+            UnregisterHotKey(helper.Handle, 9000);
+            base.OnClosed(e);
+        }
+
+        [DllImport("user32.dll")]
+        private static extern bool RegisterHotKey(IntPtr hWnd, int id, int fsModifiers, int vk);
+
+        [DllImport("user32.dll")]
+        private static extern bool UnregisterHotKey(IntPtr hWnd, int id);
+
+        private async void SearchBox_TextChanged(object sender, TextChangedEventArgs e)
+        {
+            if (ResultsList == null) return;
+
+            var query = SearchBox.Text.Trim();
+            if (query.Length < 2)
+            {
+                ResultsList.Visibility = Visibility.Collapsed;
+                ResultsList.ItemsSource = null;
+                return;
+            }
+
+            if (!Indexer.IsReady)
+            {
+                await Indexer.LoadIndexAsync();
+                Indexer.MarkAsReady();
+            }
+
+            var results = Indexer.Search(query);
+
+            if (!results.Any())
+            {
+                results.Add(new SearchResult
+                {
+                    DisplayName = $"Search Google for \"{query}\"",
+                    FullPath = $"https://www.google.com/search?q={Uri.EscapeDataString(query)}"
+                });
+            }
+
+            ResultsList.ItemsSource = results;
+            ResultsList.Visibility = Visibility.Visible;
+
+            foreach (var item in results)
+            {
+                LoadIconForResult(item);
+            }
+        }
+
+        private void ResultsList_MouseDoubleClick(object sender, MouseButtonEventArgs e)
+        {
+            if (ResultsList.SelectedItem == null) return;
+
+            var selected = ResultsList.SelectedItem as SearchResult;
+            if (selected == null) return;
+
+            if (selected.FullPath.StartsWith("http"))
+            {
+                Process.Start(new ProcessStartInfo(selected.FullPath)
+                {
+                    UseShellExecute = true
+                });
+            }
+            else
+            {
+                Process.Start(new ProcessStartInfo(selected.FullPath)
+                {
+                    UseShellExecute = true
+                });
+            }
+
+            this.Hide();
+        }
+
+        public class SearchResult
+        {
+            public string DisplayName { get; set; }
+            public string FullPath { get; set; }
+            public ImageSource Icon { get; set; }
+            public bool IsFolder { get; set; }
+
+            public override string ToString()
+            {
+                return DisplayName;
+            }
+        }
+
+        [DllImport("user32.dll")]
+        internal static extern int SetWindowCompositionAttribute(IntPtr hwnd, ref WindowCompositionAttributeData data);
+
+        private void ApplyBlurEffect()
+        {
+            var windowHelper = new WindowInteropHelper(this);
+            var accent = new AccentPolicy
+            {
+                AccentState = AccentState.ACCENT_ENABLE_BLURBEHIND
+            };
+
+            var accentStructSize = Marshal.SizeOf(accent);
+            var accentPtr = Marshal.AllocHGlobal(accentStructSize);
+            Marshal.StructureToPtr(accent, accentPtr, false);
+
+            var data = new WindowCompositionAttributeData
+            {
+                Attribute = WindowCompositionAttribute.WCA_ACCENT_POLICY,
+                SizeOfData = accentStructSize,
+                Data = accentPtr
+            };
+
+            SetWindowCompositionAttribute(windowHelper.Handle, ref data);
+            Marshal.FreeHGlobal(accentPtr);
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        internal struct AccentPolicy
+        {
+            public AccentState AccentState;
+            public int AccentFlags;
+            public int GradientColor;
+            public int AnimationId;
+        }
+
+        internal enum AccentState
+        {
+            ACCENT_DISABLED = 0,
+            ACCENT_ENABLE_GRADIENT = 1,
+            ACCENT_ENABLE_TRANSPARENTGRADIENT = 2,
+            ACCENT_ENABLE_BLURBEHIND = 3,
+            ACCENT_ENABLE_ACRYLICBLURBEHIND = 4,
+            ACCENT_ENABLE_HOSTBACKDROP = 5
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        internal struct WindowCompositionAttributeData
+        {
+            public WindowCompositionAttribute Attribute;
+            public IntPtr Data;
+            public int SizeOfData;
+        }
+
+        internal enum WindowCompositionAttribute
+        {
+            WCA_ACCENT_POLICY = 19
+        }
+
+        // Menu contextuel des différents éléments de la liste
+        /*
+        
+        <MenuItem Header="Ouvrir" Click="OpenFile_Click"/>
+                                    <MenuItem Header="Ouvrir l'emplacement" Click="OpenLocation_Click"/>
+                                    <MenuItem Header="Copier le chemin" Click="CopyPath_Click"/>
+                                    <MenuItem Header="Supprimer" Click="DeleteFile_Click"/>
+                                    <MenuItem Header="Renommer" Click="RenameFile_Click"/>
+                                    <MenuItem Header="Propriétés" Click="ShowProperties_Click"/>
+        
+        */
+
+        private void OpenFile_Click(object sender, RoutedEventArgs e)
+        {
+            if (ResultsList.SelectedItem is SearchResult selected)
+            {
+                Process.Start(new ProcessStartInfo(selected.FullPath) { UseShellExecute = true });
+            }
+        }
+        private void OpenLocation_Click(object sender, RoutedEventArgs e)
+        {
+            if (ResultsList.SelectedItem is SearchResult selected)
+            {
+                Process.Start(new ProcessStartInfo("explorer.exe", $"/select,\"{selected.FullPath}\""));
+            }
+        }
+        private void CopyPath_Click(object sender, RoutedEventArgs e)
+        {
+            if (ResultsList.SelectedItem is SearchResult selected)
+            {
+                Clipboard.SetText(selected.FullPath);
+            }
+        }
+        private void DeleteFile_Click(object sender, RoutedEventArgs e)
+        {
+            if (ResultsList.SelectedItem is SearchResult selected)
+            {
+                if (MessageBox.Show($"Êtes-vous sûr de vouloir supprimer {selected.DisplayName} ?", "Confirmation", MessageBoxButton.YesNo, MessageBoxImage.Warning) == MessageBoxResult.Yes)
+                {
+                    try
+                    {
+                        File.Delete(selected.FullPath);
+                        MessageBox.Show($"{selected.DisplayName} a été supprimé avec succès.", "Succès", MessageBoxButton.OK, MessageBoxImage.Information);
+                    }
+                    catch (Exception ex)
+                    {
+                        MessageBox.Show($"Erreur lors de la suppression : {ex.Message}", "Erreur", MessageBoxButton.OK, MessageBoxImage.Error);
+                    }
+                }
+            }
+        }
+        private void RenameFile_Click(object sender, RoutedEventArgs e)
+        {
+            if (ResultsList.SelectedItem is SearchResult selected)
+            {
+                string newName = Microsoft.VisualBasic.Interaction.InputBox("Entrez le nouveau nom :", "Renommer le fichier", selected.DisplayName);
+                if (!string.IsNullOrEmpty(newName))
+                {
+                    try
+                    {
+                        string newPath = Path.Combine(Path.GetDirectoryName(selected.FullPath), newName);
+                        File.Move(selected.FullPath, newPath);
+                        MessageBox.Show($"{selected.DisplayName} a été renommé en {newName}.", "Succès", MessageBoxButton.OK, MessageBoxImage.Information);
+                    }
+                    catch (Exception ex)
+                    {
+                        MessageBox.Show($"Erreur lors du renommage : {ex.Message}", "Erreur", MessageBoxButton.OK, MessageBoxImage.Error);
+                    }
+                }
+            }
+        }
+        private void ShowProperties_Click(object sender, RoutedEventArgs e)
+        {
+            if (ResultsList.SelectedItem is SearchResult selected)
+            {
+                Process.Start(new ProcessStartInfo("explorer.exe", $"/select,\"{selected.FullPath}\""));
+            }
+        }
+    }
+
+    public class StringNullOrEmptyToVisibilityConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            if (value is string str && !string.IsNullOrEmpty(str))
+            {
+                return Visibility.Visible;
+            }
+            return Visibility.Collapsed;
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            throw new NotImplementedException();
+        }
+    }
+
+    public class StringNotNullOrEmptyToVisibilityConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            return string.IsNullOrEmpty(value as string) ? Visibility.Visible : Visibility.Collapsed;
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/WannaTool/MainWindow.xaml.cs
+++ b/WannaTool/MainWindow.xaml.cs
@@ -268,11 +268,6 @@ namespace WannaTool
                 return;
             }
 
-            if (!Indexer.IsReady)
-            {
-                await Indexer.LoadIndexAsync();
-                Indexer.MarkAsReady();
-            }
 
             var colon = query.IndexOf(':');
             if (colon > 0 && colon < query.Length - 1)

--- a/WannaTool/Properties/PublishProfiles/FolderProfile.pubxml
+++ b/WannaTool/Properties/PublishProfiles/FolderProfile.pubxml
@@ -1,0 +1,16 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!-- https://go.microsoft.com/fwlink/?LinkID=208121. -->
+<Project>
+  <PropertyGroup>
+    <Configuration>Release</Configuration>
+    <Platform>Any CPU</Platform>
+    <PublishDir>bin\Release\net8.0-windows10.0.19041.0\publish\win-x64\</PublishDir>
+    <PublishProtocol>FileSystem</PublishProtocol>
+    <_TargetId>Folder</_TargetId>
+    <TargetFramework>net8.0-windows10.0.19041.0</TargetFramework>
+    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
+    <SelfContained>false</SelfContained>
+    <PublishSingleFile>true</PublishSingleFile>
+    <PublishReadyToRun>false</PublishReadyToRun>
+  </PropertyGroup>
+</Project>

--- a/WannaTool/WannaTool.csproj
+++ b/WannaTool/WannaTool.csproj
@@ -10,6 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Toolkit.Uwp.Notifications" Version="7.1.3" />
     <PackageReference Include="System.Data.OleDb" Version="10.0.0-preview.3.25171.5" />
     <PackageReference Include="System.Drawing.Common" Version="9.0.4" />
   </ItemGroup>

--- a/WannaTool/WannaTool.csproj
+++ b/WannaTool/WannaTool.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
@@ -24,12 +24,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="DotNetEnv" Version="3.1.1" />
     <PackageReference Include="LiteDB" Version="5.0.21" />
     <PackageReference Include="Microsoft.Toolkit.Uwp.Notifications" Version="7.1.3" />
     <PackageReference Include="NHotkey.Wpf" Version="3.0.0" />
-    <PackageReference Include="System.Data.OleDb" Version="10.0.0-preview.3.25171.5" />
-    <PackageReference Include="System.Data.SQLite.Core" Version="1.0.119" />
     <PackageReference Include="System.Drawing.Common" Version="9.0.4" />
     <PackageReference Include="System.Runtime.Caching" Version="9.0.4" />
   </ItemGroup>

--- a/WannaTool/WannaTool.csproj
+++ b/WannaTool/WannaTool.csproj
@@ -10,9 +10,28 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <None Remove="Docs\index.html" />
+    <None Remove="Docs\style.css" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Content Include="Docs\index.html">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Docs\style.css">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="DotNetEnv" Version="3.1.1" />
+    <PackageReference Include="LiteDB" Version="5.0.21" />
     <PackageReference Include="Microsoft.Toolkit.Uwp.Notifications" Version="7.1.3" />
+    <PackageReference Include="NHotkey.Wpf" Version="3.0.0" />
     <PackageReference Include="System.Data.OleDb" Version="10.0.0-preview.3.25171.5" />
+    <PackageReference Include="System.Data.SQLite.Core" Version="1.0.119" />
     <PackageReference Include="System.Drawing.Common" Version="9.0.4" />
+    <PackageReference Include="System.Runtime.Caching" Version="9.0.4" />
   </ItemGroup>
 
 </Project>

--- a/WannaTool/WannaTool.csproj
+++ b/WannaTool/WannaTool.csproj
@@ -1,0 +1,17 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>WinExe</OutputType>
+    <TargetFramework>net8.0-windows10.0.19041.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <UseWPF>true</UseWPF>
+    <UseWindowsForms>True</UseWindowsForms>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="System.Data.OleDb" Version="10.0.0-preview.3.25171.5" />
+    <PackageReference Include="System.Drawing.Common" Version="9.0.4" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **High Risk**
> High risk due to new OS-integrated behavior (global hotkeys, tray app lifecycle), local filesystem crawling/indexing via LiteDB, and `Process.Start` execution paths/URLs, which can impact performance and security expectations.
> 
> **Overview**
> Adds the first `WannaTool` WPF application (`net8.0-windows`) including a borderless launcher UI toggled via `Alt+Space`, plus a tray icon with an Exit flow.
> 
> Implements local indexing/search using `LiteDB` (`Indexer`) over common user folders, result icons via shell icon extraction (`IconLoader`), debounced search with file-type filters (`exe:`, `pdf:`, `img:`, etc.), and command redirects like `google:query`, `!help`, and `!exit`.
> 
> Adds screenshot capture features on `Ctrl+Shift+F5/F6` that copy the image to the clipboard, save PNGs under `Pictures/WannaTool_Captures`, and show actionable Windows toast notifications; includes a bundled HTML/CSS help page copied to output.
> 
> Also adds solution/project scaffolding and repo hygiene tweaks (`.editorconfig` rule, `.gitattributes` linguist mappings, `.gitignore` for `.vs/`, small README wording fix).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d3631d6add6f3bf3aa081944d1a77eb87ad91179. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->